### PR TITLE
[ Feat ] user profile exception

### DIFF
--- a/src/main/java/com/backend/simya/domain/jwt/service/TokenProvider.java
+++ b/src/main/java/com/backend/simya/domain/jwt/service/TokenProvider.java
@@ -1,6 +1,7 @@
 package com.backend.simya.domain.jwt.service;
 
 import com.backend.simya.domain.jwt.dto.response.TokenDto;
+import com.backend.simya.global.common.BaseException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
@@ -9,13 +9,13 @@ import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.domain.user.service.UserService;
 import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.common.BaseResponse;
+import com.backend.simya.global.common.ValidErrorDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-
-import static com.backend.simya.global.common.BaseResponseStatus.USERS_NOT_AUTHORIZED;
 
 @Slf4j
 @RestController
@@ -24,29 +24,26 @@ import static com.backend.simya.global.common.BaseResponseStatus.USERS_NOT_AUTHO
 public class ProfileController {
 
     private final ProfileService profileService;
-    //    private final AuthService authService;
     private final UserService userService;
 
     @PostMapping("")
-    public BaseResponse<ProfileResponseDto> createProfile(@Valid @RequestBody ProfileRequestDto profileRequestDto) {
+    public BaseResponse createProfile(@Valid @RequestBody ProfileRequestDto profileRequestDto, Errors errors) {
 
         User user = null;
         try {
+            if (errors.hasErrors()) {
+                ValidErrorDetails errorDetails = new ValidErrorDetails();
+                return new BaseResponse<>(errorDetails.validateHandling(errors));
+            }
 //        User user = authService.authenticateUser();  // 현재 접속한 유저
             user = userService.getMyUserWithAuthorities();
             log.info("ProfileController - user: {}", user);
-        } catch (BaseException e) {
-            if (user == null) {
-                return new BaseResponse<>(e.getStatus());
-            }
-        }
 
-        try {
             profileRequestDto.setUserProfile(user);
             ProfileResponseDto profileResponseDto = profileService.createProfile(profileRequestDto);
             return new BaseResponse<>(profileResponseDto);
-        } catch (BaseException exception) {
-            return new BaseResponse<>(exception.getStatus());
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
         }
     }
 
@@ -59,8 +56,8 @@ public class ProfileController {
 
             String result = "프로필 수정이 완료되었습니다.";
             return new BaseResponse<>(result);
-        } catch (BaseException exception) {
-            return new BaseResponse<>(exception.getStatus());
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
         }
     }
 
@@ -71,8 +68,8 @@ public class ProfileController {
             profileService.deleteProfile(profileId);
             String result = "프로필이 삭제되었습니다.";
             return new BaseResponse<>(result);
-        } catch (BaseException exception) {
-            return new BaseResponse<>(exception.getStatus());
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
         }
     }
 
@@ -82,8 +79,8 @@ public class ProfileController {
             profileService.setMainProfile(profileId);
             String result = "메인 프로필이 변경되었습니다.";
             return new BaseResponse<>(result);
-        } catch (BaseException exception) {
-            return new BaseResponse<>(exception.getStatus());
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
         }
     }
 
@@ -91,8 +88,8 @@ public class ProfileController {
     public BaseResponse<Profile> getProfileInfo(@PathVariable("profileId") Long profileId) {
         try {
             return new BaseResponse<>(profileService.getProfileInfo(profileId));
-        } catch (BaseException exception) {
-            return new BaseResponse<>(exception.getStatus());
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
         }
     }
 }

--- a/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
@@ -28,21 +28,22 @@ public class ProfileController {
     private final UserService userService;
 
     @PostMapping("")
-    public BaseResponse<ProfileResponseDto> createProfile(@Valid @RequestBody ProfileRequestDto profileRequestDto) throws BaseException {
+    public BaseResponse<ProfileResponseDto> createProfile(@Valid @RequestBody ProfileRequestDto profileRequestDto) {
 
+        User user = null;
+        try {
 //        User user = authService.authenticateUser();  // 현재 접속한 유저
-        User user = userService.getMyUserWithAuthorities().orElseThrow(
-                () -> new BaseException(USERS_NOT_AUTHORIZED)
-        );
-        log.info("ProfileController - user: {}", user);
-        if (user == null) {
-            return new BaseResponse("존재하지 않는 사용자입니다.");   // TODO Custom Status ENUM 으로 만들어서 관리
+            user = userService.getMyUserWithAuthorities();
+            log.info("ProfileController - user: {}", user);
+        } catch (BaseException e) {
+            if (user == null) {
+                return new BaseResponse<>(e.getStatus());
+            }
         }
 
         try {
             profileRequestDto.setUserProfile(user);
             ProfileResponseDto profileResponseDto = profileService.createProfile(profileRequestDto);
-
             return new BaseResponse<>(profileResponseDto);
         } catch (BaseException exception) {
             return new BaseResponse<>(exception.getStatus());

--- a/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
@@ -5,6 +5,7 @@ import com.backend.simya.domain.user.entity.User;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -12,7 +13,7 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class ProfileRequestDto {
 
-    @NotNull
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
     @Size(min = 1, max = 20)
     private String nickname;
 
@@ -22,6 +23,7 @@ public class ProfileRequestDto {
 
     private User user;
 
+    // TODO User 에서 addProfileList 할 때 한번에 처리하기
     public void setUserProfile(User user) {
         this.user = user;
     }

--- a/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
@@ -1,6 +1,7 @@
 package com.backend.simya.domain.profile.dto.request;
 
 import com.backend.simya.domain.profile.entity.Profile;
+import com.backend.simya.domain.user.dto.request.UserDto;
 import com.backend.simya.domain.user.entity.User;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/backend/simya/domain/profile/entity/Profile.java
+++ b/src/main/java/com/backend/simya/domain/profile/entity/Profile.java
@@ -47,9 +47,12 @@ public class Profile extends BaseTimeEntity {
     private boolean activated;
 
 
+    public void setUserProfile(User user) {
+        this.user = user;
+    }
+
     public void selectMainProfile() {
         this.isRepresent = true;
-        System.out.println("Profile Entity - selectMainProfile() 실행");
     }
 
     public void cancelMainProfile() {

--- a/src/main/java/com/backend/simya/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/backend/simya/domain/profile/service/ProfileService.java
@@ -32,7 +32,7 @@ public class ProfileService {
             Long profileId = profileRepository.save(profile).getProfileId();
             return new ProfileResponseDto(profileId, profile.getNickname(), profile.getUser());
         } catch (Exception ignored) {
-            throw new BaseException(DATABASE_ERROR);
+            throw new BaseException(POST_FAIL_PROFILE);
         }
 
     }
@@ -52,17 +52,27 @@ public class ProfileService {
     // 대표 프로필은 하나만 지정 가능
     public void setMainProfile(Long profileId) throws BaseException {
         Profile profile = getProfileInfo(profileId);
-        User user = profile.getUser();
 
-        int idx = user.getMainProfile();  // 이미 대표 프로필이 존재한다면 해제 후 선택
-        log.info("현재 유저의 main profile index: {}", idx);
+        try {
+            User user = profile.getUser();
+            if (user == null) {
+                throw new BaseException(GET_FAIL_USERINFO);
+            }
 
-        if (idx == -1) {  // 대표 프로필로 지정된 것이 없다면 바로 선택
-            profile.selectMainProfile();
-            log.info("변경 후 main profile index: {}", user.getMainProfile());
-        } else {
-            user.getProfileList().get(idx).cancelMainProfile();
-            profile.selectMainProfile();
+            int idx = user.getMainProfile();  // 이미 대표 프로필이 존재한다면 해제 후 선택
+            log.info("현재 유저의 main profile index: {}", idx);
+
+            if (idx == -1) {  // 대표 프로필로 지정된 것이 없다면 바로 선택
+                profile.selectMainProfile();
+                log.info("변경 후 main profile index: {}", user.getMainProfile());
+            } else {
+                user.getProfileList().get(idx).cancelMainProfile();
+                profile.selectMainProfile();
+            }
+        } catch (IndexOutOfBoundsException exception) {
+            throw new BaseException(USERS_NEED_ONE_MORE_PROFILE);
+        } catch (Exception ignored) {
+            throw new BaseException(SET_FAIL_MAIN_PROFILE);
         }
     }
 
@@ -70,7 +80,14 @@ public class ProfileService {
     public void deleteProfile(Long profileId) throws BaseException {
         try {
             Profile profile = getProfileInfo(profileId);
-            profile.delete(profileId);
+            if (profile.isActivated()) {
+                if (profile.getUser().getProfileList().isEmpty()) {
+                    throw new BaseException(USERS_NEED_ONE_MORE_PROFILE);
+                }
+                profile.delete(profileId);
+            } else {
+                throw new BaseException(ALREADY_DELETE_PROFILE);
+            }
         } catch (Exception ignored) {
             throw new BaseException(DELETE_FAIL_PROFILE);
         }

--- a/src/main/java/com/backend/simya/domain/user/controller/OauthController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/OauthController.java
@@ -4,6 +4,7 @@ import com.backend.simya.domain.jwt.dto.response.TokenDto;
 import com.backend.simya.domain.jwt.service.AuthService;
 import com.backend.simya.domain.user.dto.response.KakaoTokenDto;
 import com.backend.simya.domain.user.service.OauthService;
+import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.common.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -23,14 +24,20 @@ public class OauthController {
     // 임시 URI 경로
     // https://kauth.kakao.com/oauth/authorize?client_id=4ab7b193bdd041a30446ede285a1f77a&redirect_uri=http://localhost:8080/api/authorization_code&response_type=code
     @GetMapping("/api/authorization_code")  // redirect uri로 code받아오고, access_token을 받아온다
-    public ResponseEntity<TokenDto> getLogin(@RequestParam("code") String code) {
-        // 인가코드를 넘겨주고 카카오 서버에게 액세스 토큰 발급 요청
-        KakaoTokenDto kakaoTokenDto = oauthService.getKakaoAccessToken(code);
-        // 발급받은 액세스 토큰으로 카카오 서버에 회원정보 요청 후 DB에 저장
-        TokenDto jwtTokenDto = oauthService.saveKakaoUser(kakaoTokenDto.getAccess_token());
-        HttpHeaders headers = authService.inputTokenInHeader(jwtTokenDto);
+    public ResponseEntity getLogin(@RequestParam("code") String code) {
 
-        return ResponseEntity.ok().headers(headers).body(jwtTokenDto);
+        try {
+            // 인가코드를 넘겨주고 카카오 서버에게 액세스 토큰 발급 요청
+            KakaoTokenDto kakaoTokenDto = oauthService.getKakaoAccessToken(code);
+            // 발급받은 액세스 토큰으로 카카오 서버에 회원정보 요청 후 DB에 저장
+            TokenDto jwtTokenDto = oauthService.saveKakaoUser(kakaoTokenDto.getAccess_token());
+            HttpHeaders headers = authService.inputTokenInHeader(jwtTokenDto);
+
+            // TODO BaseResponse 리턴하도록 변경
+            return ResponseEntity.ok().headers(headers).body(jwtTokenDto);
+        } catch (BaseException e) {
+            return ResponseEntity.ok(e.getStatus());
+        }
     }
 
     @GetMapping("/api/code")
@@ -41,10 +48,15 @@ public class OauthController {
     }
 
     // 인가코드 과정 없이 바로 맥세스 토큰 받아오기
-    public ResponseEntity<TokenDto> getKakaoAccessToken(@RequestParam("token") String token) {
-        TokenDto jwtTokenDto = oauthService.saveKakaoUser(token);
-        HttpHeaders headers = authService.inputTokenInHeader(jwtTokenDto);
+    public ResponseEntity getKakaoAccessToken(@RequestParam("token") String token) {
+        try {
+            TokenDto jwtTokenDto = oauthService.saveKakaoUser(token);
 
-        return ResponseEntity.ok().headers(headers).body(jwtTokenDto);
+            HttpHeaders headers = authService.inputTokenInHeader(jwtTokenDto);
+
+            return ResponseEntity.ok().headers(headers).body(jwtTokenDto);
+        } catch (BaseException e) {
+            return ResponseEntity.ok(e.getStatus());
+        }
     }
 }

--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
         try {
             return new BaseResponse<>(userService.formSignup(userDto));
         } catch (BaseException e) {
-            return new BaseResponse(e.getStatus());
+            return new BaseResponse<>(e.getStatus());
         }
     }
 
@@ -44,21 +44,30 @@ public class UserController {
 //            response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Refresh  " + refreshToken);// 토큰 헤더에 넣기
             return new BaseResponse<>(tokenDto);
         } catch (BaseException e) {
-            return new BaseResponse(e.getStatus());
+            return new BaseResponse<>(e.getStatus());
         }
     }
 
-    @GetMapping("/user")
+    @GetMapping("/mypage")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")  // USER, ADMIN 권한 모두 허용
     public BaseResponse<User> getMyUserInfo() {
-        User userResponse = userService.getMyUserWithAuthorities().get();
-        return new BaseResponse<>(userResponse);
+        try {
+            User userResponse = userService.getMyUserWithAuthorities();
+            return new BaseResponse<>(userResponse);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
     }
 
     @GetMapping("/user/{username}")
     @PreAuthorize("hasAnyRole('ADMIN')")   // ADMIN 권한만 허용 -> API를 호출 가능한 권한을 제한함
     public BaseResponse<User> getUserInfo(@PathVariable String username) {
-        User userResponse = userService.getUserWithAuthorities(username).get();
-        return new BaseResponse<>(userResponse);
+        try {
+            User userResponse = userService.getUserWithAuthorities(username);
+            return new BaseResponse<>(userResponse);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
     }
 }

--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -44,13 +44,21 @@ public class UserController {
     }
 
     @GetMapping("/form-login")
-    public BaseResponse<TokenDto> formLogin(@Valid @RequestBody LoginDto loginDto, HttpServletResponse response) {
+    public BaseResponse formLogin(@Valid @RequestBody LoginDto loginDto, HttpServletResponse response, Errors errors) {
         try{
+            if (errors.hasErrors()) {
+                ValidErrorDetails errorDetails = new ValidErrorDetails();
+                return new BaseResponse<>(errorDetails.validateHandling(errors));
+            }
+
             TokenDto tokenDto = authService.login(loginDto);
             String accessToken = tokenDto.getAccessToken();
             String refreshToken = tokenDto.getRefreshToken();
+
+            // 헤더에 토큰 추가
             response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + accessToken);
-//            response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Refresh  " + refreshToken);// 토큰 헤더에 넣기
+            response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Refresh  " + refreshToken);
+
             return new BaseResponse<>(tokenDto);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -8,14 +8,18 @@ import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.domain.user.service.UserService;
 import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.common.BaseResponse;
+import com.backend.simya.global.common.ValidErrorDetails;
 import com.backend.simya.global.config.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
+@Slf4j
 @RestController
 @RequestMapping("/simya")
 @RequiredArgsConstructor
@@ -26,8 +30,13 @@ public class UserController {
 
 
     @PostMapping("/form-signup")
-    public BaseResponse<UserDto> signup(@Valid @RequestBody UserDto userDto) {
+    public BaseResponse signup(@Valid @RequestBody UserDto userDto, Errors errors) {
         try {
+            if (errors.hasErrors()) {
+                log.info("ValidError: {}", errors);
+                ValidErrorDetails errorDetails = new ValidErrorDetails();
+                return new BaseResponse<>(errorDetails.validateHandling(errors));
+            }
             return new BaseResponse<>(userService.formSignup(userDto));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/src/main/java/com/backend/simya/domain/user/dto/request/LoginDto.java
+++ b/src/main/java/com/backend/simya/domain/user/dto/request/LoginDto.java
@@ -3,6 +3,7 @@ package com.backend.simya.domain.user.dto.request;
 import lombok.*;
 
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -15,12 +16,12 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class LoginDto {
 
-    @NotNull
-    @Email
+    @NotBlank(message = "아이디는 필수 입력 값입니다,")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     @Size(min = 3, max = 50)
     private String email;
 
-    @NotNull
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다,")
     @Size(min = 3, max = 100)
     private String password;
 }

--- a/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
+++ b/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
@@ -15,8 +15,8 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class UserDto {
 
-    @Email
-    @NotNull
+    @Email(message = "이메일 형식을 확인해주세요.")
+    @NotNull(message = "이메일을 입력해주세요.")
     @Size(min = 3, max = 50)
     private String email;
 

--- a/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
+++ b/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
@@ -4,9 +4,7 @@ import com.backend.simya.domain.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 
 
 @Getter @Setter
@@ -15,14 +13,14 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class UserDto {
 
-    @Email(message = "이메일 형식을 확인해주세요.")
-    @NotNull(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
     @Size(min = 3, max = 50)
     private String email;
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-    @NotNull
-    @Size(min = 3, max = 100)
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String password;
 
     public static UserDto from(User user) {

--- a/src/main/java/com/backend/simya/domain/user/entity/User.java
+++ b/src/main/java/com/backend/simya/domain/user/entity/User.java
@@ -122,6 +122,7 @@ public class User extends BaseTimeEntity implements UserDetails {
     //== 연관관계 매핑 메서드 ==//
     public void addProfile(Profile profile) {
         profileList.add(profile);
+        profile.setUserProfile(this);
     }
 
     public int getMainProfile() {
@@ -132,4 +133,9 @@ public class User extends BaseTimeEntity implements UserDetails {
         }
         return -1;
     }
+
+    /*public User toEntity() {
+        return User.builder()
+                .
+    }*/
 }

--- a/src/main/java/com/backend/simya/domain/user/service/UserService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/UserService.java
@@ -9,13 +9,12 @@ import com.backend.simya.domain.user.repository.UserRepository;
 import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
-import static com.backend.simya.global.common.BaseResponseStatus.POST_USERS_EXISTS_EMAIL;
+import static com.backend.simya.global.common.BaseResponseStatus.*;
 
 /**
  * 회원가입, 유저정보조회 등의 API를 구현하기 위한 Service 클래스
@@ -29,32 +28,53 @@ public class UserService {
 
     @Transactional
     public UserDto formSignup(UserDto userDto) throws BaseException {
-        if (userRepository.existsByEmail(userDto.getEmail())) {
-            throw new BaseException(POST_USERS_EXISTS_EMAIL);
-        } else {
-            User newUser = User.builder()
-                    .email(userDto.getEmail())
-                    .pw(passwordEncoder.encode(userDto.getPassword()))
-                    .loginType(LoginType.FORM)
-                    .role(Role.ROLE_USER)
-                    .activated(true)
-                    .build();
 
-            return UserDto.from(userRepository.save(newUser));
+        try {
+            if (userRepository.existsByEmail(userDto.getEmail())) {
+                throw new BaseException(POST_USERS_EXISTS_EMAIL);
+            } else {
+                User newUser = User.builder()
+                        .email(userDto.getEmail())
+                        .pw(passwordEncoder.encode(userDto.getPassword()))
+                        .loginType(LoginType.FORM)
+                        .role(Role.ROLE_USER)
+                        .activated(true)
+                        .build();
+
+                return UserDto.from(userRepository.save(newUser));
+            }
+        } catch (Exception exception) {
+            throw new BaseException(POST_FAIL_USER);
         }
     }
 
     //== 유저, 권한정보를 가져오는 메소드 ==//
     // email 을 기준으로 정보를 가져온다.
     @Transactional(readOnly = true)
-    public Optional<User> getUserWithAuthorities(String username) {
-        return userRepository.findOneWithAuthoritiesByEmail(username);
+    public User getUserWithAuthorities(String username) throws BaseException {
+        try {
+            return userRepository.findOneWithAuthoritiesByEmail(username).orElseThrow(
+                    () -> new BaseException(USERS_NOT_FOUND)
+            );
+        } catch (Exception exception) {
+            if (userRepository.findByEmail(username).isPresent()) {
+                throw new BaseException(ACCESS_ONLY_ADMIN);
+            } else {
+                throw new BaseException(GET_FAIL_USERINFO);
+            }
+        }
     }
 
     // SecurityContext에 저장된 email 에 해당하는 유저, 권한의 정보만 가저온다.
     @Transactional(readOnly = true)
-    public Optional<User> getMyUserWithAuthorities() {
-        return SecurityUtil.getCurrentUsername().flatMap(userRepository::findOneWithAuthoritiesByEmail);
+    public User getMyUserWithAuthorities() throws BaseException {
+        try {
+            return SecurityUtil.getCurrentUsername().flatMap(userRepository::findOneWithAuthoritiesByEmail).orElseThrow(
+                    () -> new BaseException(USERS_NOT_FOUND)
+            );
+        } catch (Exception exception) {
+            throw new BaseException(GET_FAIL_USERINFO);
+        }
     }
 
 }

--- a/src/main/java/com/backend/simya/domain/user/service/UserService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/UserService.java
@@ -9,7 +9,6 @@ import com.backend.simya.domain.user.repository.UserRepository;
 import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/backend/simya/domain/user/service/UserService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.backend.simya.domain.user.repository.UserRepository;
 import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
+++ b/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
@@ -23,9 +23,13 @@ public enum BaseResponseStatus {
     EMPTY_JWT(false, 401, "JWT를 입력해주세요."),
     INVALID_JWT(false, 403, "유효하지 않은 JWT입니다."),
     INVALID_USER_JWT(false, 403, "권한이 없는 유저의 접근입니다."),
+    EXPIRED_JWT(false, 401, "만료된 JWT 토큰입니다."),
+    UNSUPPORTED_JWT(false, 401, "지원하지 않는 JWT 토큰입니다."),
+    MALFORMED_JWT(false, 401, "잘못된 JWT 서명입니다."),
 
     // user 관련
-    USERS_NOT_AUTHORIZED(false, 400, "인가되지 않은 사용자입니다."),
+    USERS_INVALID_ACCESS(false, 401, "잘못된 인가 접근입니다."),
+    USERS_NOT_AUTHORIZED(false, 401, "인가되지 않은 사용자입니다."),
     USERS_NOT_FOUND(false, 400, "존재하지 않는 사용자입니다."),
     USERS_EMPTY_USER_ID(false, 400, "유저 아이디 값을 확인해주세요"),
 
@@ -48,6 +52,9 @@ public enum BaseResponseStatus {
     // 503 : Service Unavailable
     DATABASE_ERROR(false, 503, "데이터베이스 연결에 실패했습니다."),
     SERVER_ERROR(false, 503, "서버와의 연결에 실패했습니다."),
+
+    FAILED_TO_JWT(false, 500, "토큰 발급에 실패했습니다."),
+    FAILED_JWT_IN_HEADER(false, 500, "JWT 토큰이 헤더에 정상적으로 들어가지 않았습니다."),
 
     GET_FAIL_USERINFO(false, 500, "회원정보 조회에 실패했습니다"),
     POST_FAIL_USER(false, 500, "회원가입에 실패했습니다."),

--- a/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
+++ b/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
@@ -25,14 +25,16 @@ public enum BaseResponseStatus {
     INVALID_USER_JWT(false, 403, "권한이 없는 유저의 접근입니다."),
 
     // user 관련
-    USERS_NOT_AUTHORIZED(false, 2009, "인가되지 않은 사용자입니다."),
-    USERS_EMPTY_USER_ID(false, 2010, "유저 아이디 값을 확인해주세요"),
-    POST_USERS_EMPTY_EMAIL(false, 2015, "이메일을 입력해주세요."),
-    POST_USERS_INVALID_EMAIL(false, 2016, "이메일 형식을 확인해주세요."),
-    POST_USERS_EXISTS_EMAIL(false, 2017, "중복된 이메일입니다."),
+    USERS_NOT_AUTHORIZED(false, 400, "인가되지 않은 사용자입니다."),
+    USERS_NOT_FOUND(false, 400, "존재하지 않는 사용자입니다."),
+    USERS_EMPTY_USER_ID(false, 400, "유저 아이디 값을 확인해주세요"),
+
+    POST_USERS_EXISTS_EMAIL(false, 400, "중복된 이메일입니다."),
 
     POST_USERS_EMPTY_PASSWORD(false, 400, "비밀번호를 입력해주세요."),
     USERS_PASSWORD_FORMAT(false, 400, "비밀번호는 8자 이상의 영문 대소문자와 특수문자로 구성해야 합니다."),
+
+    ACCESS_ONLY_ADMIN(false, 400, "관리자만 접근 가능합니다."),
 
 
     // user 관련
@@ -47,15 +49,18 @@ public enum BaseResponseStatus {
     DATABASE_ERROR(false, 503, "데이터베이스 연결에 실패했습니다."),
     SERVER_ERROR(false, 503, "서버와의 연결에 실패했습니다."),
 
+    GET_FAIL_USERINFO(false, 500, "회원정보 조회에 실패했습니다"),
+    POST_FAIL_USER(false, 500, "회원가입에 실패했습니다."),
+
     // [PATCH] user 정보 수정 시
-    MODIFY_FAIL_USERNAME(false, 4014, "회원 이름을 변경하는 데 실패했습니다."),
-    MODIFY_FAIL_POSTS_INFO(false, 4015, "게시글 정보 수정에 실패했습니다."),
+    MODIFY_FAIL_USERNAME(false, 500, "회원 이름을 변경하는 데 실패했습니다."),
+    MODIFY_FAIL_POSTS_INFO(false, 500, "게시글 정보 수정에 실패했습니다."),
 
-    DELETE_FAIL_PROFILE(false, 4100, "프로필 삭제에 실패했습니다."),
-    UPDATE_FAIL_PROFILE(false, 4100, "프로필 수정에 실패했습니다."),
+    DELETE_FAIL_PROFILE(false, 500, "프로필 삭제에 실패했습니다."),
+    UPDATE_FAIL_PROFILE(false, 500, "프로필 수정에 실패했습니다."),
 
-    PASSWORD_ENCRYPTION_ERROR(false, 4011, "비밀번호 암호화에 실패했습니다."),
-    PASSWORD_DECRYPTION_ERROR(false, 4012, "비밀번호 복호화에 실패했습니다.");
+    PASSWORD_ENCRYPTION_ERROR(false, 500, "비밀번호 암호화에 실패했습니다."),
+    PASSWORD_DECRYPTION_ERROR(false, 500, "비밀번호 복호화에 실패했습니다.");
 
     /**
      * 5000, 6000 : 필요 시 추가 구현

--- a/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
+++ b/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
@@ -45,6 +45,9 @@ public enum BaseResponseStatus {
     FAILED_TO_LOGIN(false, 404, "존재하지 않는 아이디이거나 비밀번호가 틀렸습니다."),
     BANNED_USER_IN_LOGIN(false, 403, "정지된 유저이므로 로그인이 불가합니다."),
 
+    USERS_NEED_ONE_MORE_PROFILE(false, 400, "모든 회원은 하나 이상의 프로필이 존재해야 합니다."),
+    ALREADY_DELETE_PROFILE(false, 400, "이미 삭제된 프로필입니다."),
+
 
 
     // 500 ~ : Database, Server 오류
@@ -63,8 +66,10 @@ public enum BaseResponseStatus {
     MODIFY_FAIL_USERNAME(false, 500, "회원 이름을 변경하는 데 실패했습니다."),
     MODIFY_FAIL_POSTS_INFO(false, 500, "게시글 정보 수정에 실패했습니다."),
 
+    POST_FAIL_PROFILE(false, 500, "프로필 생성에 실패했습니다."),
     DELETE_FAIL_PROFILE(false, 500, "프로필 삭제에 실패했습니다."),
     UPDATE_FAIL_PROFILE(false, 500, "프로필 수정에 실패했습니다."),
+    SET_FAIL_MAIN_PROFILE(false, 500, "메인 프로필 지정에 실패했습니다."),
 
     PASSWORD_ENCRYPTION_ERROR(false, 500, "비밀번호 암호화에 실패했습니다."),
     PASSWORD_DECRYPTION_ERROR(false, 500, "비밀번호 복호화에 실패했습니다.");

--- a/src/main/java/com/backend/simya/global/common/ValidErrorDetails.java
+++ b/src/main/java/com/backend/simya/global/common/ValidErrorDetails.java
@@ -1,0 +1,23 @@
+package com.backend.simya.global.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class ValidErrorDetails {
+    public Map<String, String> validateHandling(Errors errors) {
+        Map<String, String> validateDetails = new HashMap<>();
+
+        for (FieldError error : errors.getFieldErrors()) {
+            log.info("field error: {}", error.getDefaultMessage());
+            String validKeyName = String.format("valid_%s", error.getField());
+            validateDetails.put(validKeyName, error.getDefaultMessage());
+        }
+        return validateDetails;
+    }
+
+}

--- a/src/main/java/com/backend/simya/global/common/ValidErrorDetails.java
+++ b/src/main/java/com/backend/simya/global/common/ValidErrorDetails.java
@@ -1,19 +1,16 @@
 package com.backend.simya.global.common;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Slf4j
 public class ValidErrorDetails {
     public Map<String, String> validateHandling(Errors errors) {
         Map<String, String> validateDetails = new HashMap<>();
 
         for (FieldError error : errors.getFieldErrors()) {
-            log.info("field error: {}", error.getDefaultMessage());
             String validKeyName = String.format("valid_%s", error.getField());
             validateDetails.put(validKeyName, error.getDefaultMessage());
         }


### PR DESCRIPTION
### 🔄 변경사항
1. DTO 빈을 제약조건 추가 및 수정 : @NotNull → @NotBlank / message 추가하여 유효성 검사 각각에 대한 에러메시지 반환하도록
2. BaseResponseStatus 형식적 Validation 관련 부분 삭제 
3. Validation에 대한 (Controller `@Valid` 처리) 유효성 에러 클래스 커스터마이징 : `<strong>ValidErrorDetails</strong>`
4. 예외처리 - Service, Controller 수정 (User, Profile 도메인)
5.❗️ UserDto, ProfileDto 형식적 Validation 추가했으니 테스트 시에 이 부분 참고해주세요 ❗️


### ✅ TODO
- RefreshToken reissue 부분 어떻게 처리할지 -> 헤더에 Refresh Token을 담아서 읽어오는 방식으로 접근
- DTO 안에서 엔티티를 필드로 구성한 부분 수정
- DTO @jsonignore 이용해서 단순화하기

close #2 
