### PR TITLE
[ Feat ] profile user relation

### DIFF
--- a/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
@@ -32,18 +32,17 @@ public class ProfileController {
     @PostMapping("")
     public BaseResponse createProfile(@Valid @RequestBody ProfileRequestDto profileRequestDto, Errors errors) {
 
-        User user = null;
+        if (errors.hasErrors()) {
+            ValidErrorDetails errorDetails = new ValidErrorDetails();
+            return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
+        }
+
         try {
-            if (errors.hasErrors()) {
-                ValidErrorDetails errorDetails = new ValidErrorDetails();
-                return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
-            }
 //        User user = authService.authenticateUser();  // 현재 접속한 유저
-            user = userService.getMyUserWithAuthorities();
+            User user = userService.getMyUserWithAuthorities();
             log.info("ProfileController - user: {}", user);
 
-            profileRequestDto.setUserProfile(user);
-            ProfileResponseDto profileResponseDto = profileService.createProfile(profileRequestDto);
+            ProfileResponseDto profileResponseDto = profileService.createProfile(profileRequestDto, user);
             return new BaseResponse<>(profileResponseDto);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
@@ -9,6 +9,7 @@ import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.domain.user.service.UserService;
 import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.common.BaseResponse;
+import com.backend.simya.global.common.BaseResponseStatus;
 import com.backend.simya.global.common.ValidErrorDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,8 @@ import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+
+import static com.backend.simya.global.common.BaseResponseStatus.REQUEST_ERROR;
 
 @Slf4j
 @RestController
@@ -33,7 +36,7 @@ public class ProfileController {
         try {
             if (errors.hasErrors()) {
                 ValidErrorDetails errorDetails = new ValidErrorDetails();
-                return new BaseResponse<>(errorDetails.validateHandling(errors));
+                return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
             }
 //        User user = authService.authenticateUser();  // 현재 접속한 유저
             user = userService.getMyUserWithAuthorities();

--- a/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
@@ -24,19 +24,19 @@ public class ProfileRequestDto {
 
     private String picture;
 
-    private User user;
+//    private User user;
 
-    // TODO User 에서 addProfileList 할 때 한번에 처리하기
-    public void setUserProfile(User user) {
-        this.user = user;
-    }
+//    // TODO User 에서 addProfileList 할 때 한번에 처리하기
+//    public void setUserProfile(User user) {
+//        this.user = user;
+//    }
 
     public Profile toEntity() {
         return Profile.builder()
                 .nickname(nickname)
                 .comment(comment)
                 .picture(picture)
-                .user(user)
+                .user(null)
                 .isRepresent(false)
                 .activated(true)
                 .build();

--- a/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
@@ -3,6 +3,7 @@ package com.backend.simya.domain.profile.dto.request;
 import com.backend.simya.domain.profile.entity.Profile;
 import com.backend.simya.domain.user.dto.request.UserDto;
 import com.backend.simya.domain.user.entity.User;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,7 @@ import javax.validation.constraints.Size;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class ProfileRequestDto {
 
     @NotBlank(message = "닉네임은 필수 입력 값입니다.")

--- a/src/main/java/com/backend/simya/domain/profile/dto/response/ProfileResponseDto.java
+++ b/src/main/java/com/backend/simya/domain/profile/dto/response/ProfileResponseDto.java
@@ -1,5 +1,6 @@
 package com.backend.simya.domain.profile.dto.response;
 
+import com.backend.simya.domain.user.dto.request.UserDto;
 import com.backend.simya.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/backend/simya/domain/profile/dto/response/ProfileResponseDto.java
+++ b/src/main/java/com/backend/simya/domain/profile/dto/response/ProfileResponseDto.java
@@ -1,7 +1,5 @@
 package com.backend.simya.domain.profile.dto.response;
 
-import com.backend.simya.domain.user.dto.request.UserDto;
-import com.backend.simya.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -13,5 +11,5 @@ public class ProfileResponseDto {
 
     private String nickname;
 
-    private User user;
+    private String username;
 }

--- a/src/main/java/com/backend/simya/domain/profile/entity/Profile.java
+++ b/src/main/java/com/backend/simya/domain/profile/entity/Profile.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import static javax.persistence.CascadeType.ALL;
 import static javax.persistence.FetchType.LAZY;
 
 @Entity
@@ -26,7 +27,7 @@ public class Profile extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long profileId;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY, cascade = ALL)
     @JoinColumn(name = "user_id")
     @JsonBackReference
     private User user;

--- a/src/main/java/com/backend/simya/domain/profile/entity/Profile.java
+++ b/src/main/java/com/backend/simya/domain/profile/entity/Profile.java
@@ -55,6 +55,10 @@ public class Profile extends BaseTimeEntity {
         this.isRepresent = true;
     }
 
+    public void autoSetMainProfile() {
+        this.getUser().getProfileList().get(0).isRepresent = true;
+    }
+
     public void cancelMainProfile() {
         this.isRepresent = false;
     }

--- a/src/main/java/com/backend/simya/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/backend/simya/domain/profile/service/ProfileService.java
@@ -80,11 +80,16 @@ public class ProfileService {
     public void deleteProfile(Long profileId) throws BaseException {
         try {
             Profile profile = getProfileInfo(profileId);
+            boolean isMain = profile.isRepresent();
             if (profile.isActivated()) {
                 if (profile.getUser().getProfileList().isEmpty()) {
                     throw new BaseException(USERS_NEED_ONE_MORE_PROFILE);
                 }
                 profile.delete(profileId);
+
+                if (isMain) {
+                    profile.autoSetMainProfile();
+                }
             } else {
                 throw new BaseException(ALREADY_DELETE_PROFILE);
             }

--- a/src/main/java/com/backend/simya/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/backend/simya/domain/profile/service/ProfileService.java
@@ -24,13 +24,13 @@ public class ProfileService {
     private final ProfileRepository profileRepository;
 
     @Transactional
-    public ProfileResponseDto createProfile(ProfileRequestDto profileRequestDto) throws BaseException {
+    public ProfileResponseDto createProfile(ProfileRequestDto profileRequestDto, User user) throws BaseException {
 
         try {
             Profile profile = profileRequestDto.toEntity();
-            profile.getUser().addProfile(profile);
+            user.addProfile(profile);
             Long profileId = profileRepository.save(profile).getProfileId();
-            return new ProfileResponseDto(profileId, profile.getNickname(), profile.getUser());
+            return new ProfileResponseDto(profileId, profile.getNickname(), profile.getUser().getUsername());
         } catch (Exception ignored) {
             throw new BaseException(POST_FAIL_PROFILE);
         }

--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.domain.user.service.UserService;
 import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.common.BaseResponse;
+import com.backend.simya.global.common.BaseResponseStatus;
 import com.backend.simya.global.common.ValidErrorDetails;
 import com.backend.simya.global.config.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
+
+import static com.backend.simya.global.common.BaseResponseStatus.REQUEST_ERROR;
 
 @Slf4j
 @RestController
@@ -35,7 +38,7 @@ public class UserController {
             if (errors.hasErrors()) {
                 log.info("ValidError: {}", errors);
                 ValidErrorDetails errorDetails = new ValidErrorDetails();
-                return new BaseResponse<>(errorDetails.validateHandling(errors));
+                return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
             }
             return new BaseResponse<>(userService.formSignup(userDto));
         } catch (BaseException e) {
@@ -48,7 +51,7 @@ public class UserController {
         try{
             if (errors.hasErrors()) {
                 ValidErrorDetails errorDetails = new ValidErrorDetails();
-                return new BaseResponse<>(errorDetails.validateHandling(errors));
+                return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
             }
 
             TokenDto tokenDto = authService.login(loginDto);

--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -34,12 +34,14 @@ public class UserController {
 
     @PostMapping("/form-signup")
     public BaseResponse signup(@Valid @RequestBody UserDto userDto, Errors errors) {
+
+        if (errors.hasErrors()) {
+            log.info("ValidError: {}", errors);
+            ValidErrorDetails errorDetails = new ValidErrorDetails();
+            return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
+        }
+
         try {
-            if (errors.hasErrors()) {
-                log.info("ValidError: {}", errors);
-                ValidErrorDetails errorDetails = new ValidErrorDetails();
-                return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
-            }
             return new BaseResponse<>(userService.formSignup(userDto));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -48,12 +50,13 @@ public class UserController {
 
     @GetMapping("/form-login")
     public BaseResponse formLogin(@Valid @RequestBody LoginDto loginDto, HttpServletResponse response, Errors errors) {
-        try{
-            if (errors.hasErrors()) {
-                ValidErrorDetails errorDetails = new ValidErrorDetails();
-                return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
-            }
 
+        if (errors.hasErrors()) {
+            ValidErrorDetails errorDetails = new ValidErrorDetails();
+            return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
+        }
+
+        try{
             TokenDto tokenDto = authService.login(loginDto);
             String accessToken = tokenDto.getAccessToken();
             String refreshToken = tokenDto.getRefreshToken();

--- a/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
+++ b/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
@@ -1,5 +1,6 @@
 package com.backend.simya.domain.user.dto.request;
 
+import com.backend.simya.domain.profile.dto.request.ProfileRequestDto;
 import com.backend.simya.domain.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
@@ -22,6 +23,8 @@ public class UserDto {
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String password;
+
+    private ProfileRequestDto profile;
 
     public static UserDto from(User user) {
         if (user == null) return null;

--- a/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
+++ b/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
@@ -1,6 +1,7 @@
 package com.backend.simya.domain.user.dto.request;
 
 import com.backend.simya.domain.profile.dto.request.ProfileRequestDto;
+import com.backend.simya.domain.profile.entity.Profile;
 import com.backend.simya.domain.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
@@ -28,9 +29,12 @@ public class UserDto {
 
     public static UserDto from(User user) {
         if (user == null) return null;
+        Profile profile = user.getProfileList().get(0);
+        ProfileRequestDto profileRequestDto = new ProfileRequestDto(profile.getNickname(), profile.getComment(), profile.getPicture(), user);
 
         return UserDto.builder()
                 .email(user.getEmail())
+                .profile(profileRequestDto)
                 .build();
     }
 

--- a/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
+++ b/src/main/java/com/backend/simya/domain/user/dto/request/UserDto.java
@@ -30,7 +30,7 @@ public class UserDto {
     public static UserDto from(User user) {
         if (user == null) return null;
         Profile profile = user.getProfileList().get(0);
-        ProfileRequestDto profileRequestDto = new ProfileRequestDto(profile.getNickname(), profile.getComment(), profile.getPicture(), user);
+        ProfileRequestDto profileRequestDto = new ProfileRequestDto(profile.getNickname(), profile.getComment(), profile.getPicture());
 
         return UserDto.builder()
                 .email(user.getEmail())

--- a/src/main/java/com/backend/simya/domain/user/entity/User.java
+++ b/src/main/java/com/backend/simya/domain/user/entity/User.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static javax.persistence.CascadeType.ALL;
 
 @Entity    // @Entity 어노테이션: 자동으로 JPA 연동
-@Table(name = "`user`")
+@Table(name = "`USER`")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/backend/simya/domain/user/service/OauthService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/OauthService.java
@@ -13,6 +13,8 @@ import com.backend.simya.domain.user.entity.LoginType;
 import com.backend.simya.domain.user.entity.Role;
 import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.domain.user.repository.UserRepository;
+import com.backend.simya.global.common.BaseException;
+import com.backend.simya.global.common.BaseResponseStatus;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+
+import static com.backend.simya.global.common.BaseResponseStatus.POST_USERS_EXISTS_EMAIL;
 
 @Service
 @Slf4j
@@ -133,30 +137,28 @@ public class OauthService {
         KakaoAccountDto kakaoAccount = getKakaoInfo(token);
         String email = kakaoAccount.getKakao_account().getEmail();
 
-        if (userRepository.existsByEmail(email)) {
-            throw new RuntimeException("중복된 이메일의 유저가 있습니다");
-        } else {
-            User newKakaoUser = User.builder()
-                    .email(kakaoAccount.getKakao_account().getEmail())
-                    .pw("change your password!")
-                    .loginType(LoginType.KAKAO)
-                    .role(Role.ROLE_USER)
-                    .activated(true)
-                    .build();
 
-            Profile mainProfile = Profile.builder()
-                    .nickname("simya")
-                    .user(newKakaoUser)
-                    .comment(null)
-                    .picture(null)
-                    .isRepresent(true)
-                    .activated(true)
-                    .build();
-            newKakaoUser.addProfile(mainProfile);
-            profileRepository.save(mainProfile);
+        User newKakaoUser = User.builder()
+                .email(kakaoAccount.getKakao_account().getEmail())
+                .pw("change your password!")
+                .loginType(LoginType.KAKAO)
+                .role(Role.ROLE_USER)
+                .activated(true)
+                .build();
 
-            userRepository.save(newKakaoUser);
-        }
+        Profile mainProfile = Profile.builder()
+                .nickname("simya")
+                .user(newKakaoUser)
+                .comment(null)
+                .picture(null)
+                .isRepresent(true)
+                .activated(true)
+                .build();
+        newKakaoUser.addProfile(mainProfile);
+        profileRepository.save(mainProfile);
+
+        userRepository.save(newKakaoUser);
+
         return tokenProvider.createToken(email);
     }
 

--- a/src/main/java/com/backend/simya/domain/user/service/OauthService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/OauthService.java
@@ -5,6 +5,8 @@ import com.backend.simya.domain.jwt.entity.RefreshToken;
 import com.backend.simya.domain.jwt.repository.RefreshTokenRepository;
 import com.backend.simya.domain.jwt.service.AuthService;
 import com.backend.simya.domain.jwt.service.TokenProvider;
+import com.backend.simya.domain.profile.entity.Profile;
+import com.backend.simya.domain.profile.repository.ProfileRepository;
 import com.backend.simya.domain.user.dto.response.KakaoAccountDto;
 import com.backend.simya.domain.user.dto.response.KakaoTokenDto;
 import com.backend.simya.domain.user.entity.LoginType;
@@ -31,6 +33,7 @@ public class OauthService {
 
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
     private final RefreshTokenRepository tokenRepository;
     private final AuthService authService;
     private final TokenProvider tokenProvider;
@@ -140,6 +143,18 @@ public class OauthService {
                     .role(Role.ROLE_USER)
                     .activated(true)
                     .build();
+
+            Profile mainProfile = Profile.builder()
+                    .nickname("simya")
+                    .user(newKakaoUser)
+                    .comment(null)
+                    .picture(null)
+                    .isRepresent(true)
+                    .activated(true)
+                    .build();
+            newKakaoUser.addProfile(mainProfile);
+            profileRepository.save(mainProfile);
+
             userRepository.save(newKakaoUser);
         }
         return tokenProvider.createToken(email);

--- a/src/main/java/com/backend/simya/domain/user/service/UserService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/UserService.java
@@ -1,6 +1,8 @@
 package com.backend.simya.domain.user.service;
 
 
+import com.backend.simya.domain.profile.entity.Profile;
+import com.backend.simya.domain.profile.repository.ProfileRepository;
 import com.backend.simya.domain.user.dto.request.UserDto;
 import com.backend.simya.domain.user.entity.LoginType;
 import com.backend.simya.domain.user.entity.Role;
@@ -24,6 +26,7 @@ import static com.backend.simya.global.common.BaseResponseStatus.*;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -40,6 +43,17 @@ public class UserService {
                         .role(Role.ROLE_USER)
                         .activated(true)
                         .build();
+
+                Profile mainProfile = Profile.builder()
+                        .nickname(userDto.getProfile().getNickname())
+                        .user(newUser)
+                        .comment(userDto.getProfile().getComment())
+                        .picture(userDto.getProfile().getPicture())
+                        .isRepresent(true)
+                        .activated(true)
+                        .build();
+                newUser.addProfile(mainProfile);
+                profileRepository.save(mainProfile);
 
                 return UserDto.from(userRepository.save(newUser));
             }

--- a/src/main/java/com/backend/simya/domain/user/service/UserService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/UserService.java
@@ -11,7 +11,6 @@ import com.backend.simya.domain.user.repository.UserRepository;
 import com.backend.simya.global.common.BaseException;
 import com.backend.simya.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,31 +31,32 @@ public class UserService {
     @Transactional
     public UserDto formSignup(UserDto userDto) throws BaseException {
 
+        if (userRepository.existsByEmail(userDto.getEmail())) {
+            throw new BaseException(POST_USERS_EXISTS_EMAIL);
+        }
+
         try {
-            if (userRepository.existsByEmail(userDto.getEmail())) {
-                throw new BaseException(POST_USERS_EXISTS_EMAIL);
-            } else {
-                User newUser = User.builder()
-                        .email(userDto.getEmail())
-                        .pw(passwordEncoder.encode(userDto.getPassword()))
-                        .loginType(LoginType.FORM)
-                        .role(Role.ROLE_USER)
-                        .activated(true)
-                        .build();
+            User newUser = User.builder()
+                    .email(userDto.getEmail())
+                    .pw(passwordEncoder.encode(userDto.getPassword()))
+                    .loginType(LoginType.FORM)
+                    .role(Role.ROLE_USER)
+                    .activated(true)
+                    .build();
 
-                Profile mainProfile = Profile.builder()
-                        .nickname(userDto.getProfile().getNickname())
-                        .user(newUser)
-                        .comment(userDto.getProfile().getComment())
-                        .picture(userDto.getProfile().getPicture())
-                        .isRepresent(true)
-                        .activated(true)
-                        .build();
-                newUser.addProfile(mainProfile);
-                profileRepository.save(mainProfile);
+            Profile mainProfile = Profile.builder()
+                    .nickname(userDto.getProfile().getNickname())
+                    .user(newUser)
+                    .comment(userDto.getProfile().getComment())
+                    .picture(userDto.getProfile().getPicture())
+                    .isRepresent(true)
+                    .activated(true)
+                    .build();
+            newUser.addProfile(mainProfile);
+            profileRepository.save(mainProfile);
 
-                return UserDto.from(userRepository.save(newUser));
-            }
+            return UserDto.from(userRepository.save(newUser));
+
         } catch (Exception exception) {
             throw new BaseException(POST_FAIL_USER);
         }
@@ -82,13 +82,11 @@ public class UserService {
     // SecurityContext에 저장된 email 에 해당하는 유저, 권한의 정보만 가저온다.
     @Transactional(readOnly = true)
     public User getMyUserWithAuthorities() throws BaseException {
-        try {
-            return SecurityUtil.getCurrentUsername().flatMap(userRepository::findOneWithAuthoritiesByEmail).orElseThrow(
-                    () -> new BaseException(USERS_NOT_FOUND)
-            );
-        } catch (Exception exception) {
-            throw new BaseException(GET_FAIL_USERINFO);
-        }
+
+        return SecurityUtil.getCurrentUsername().flatMap(userRepository::findOneWithAuthoritiesByEmail).orElseThrow(
+                () -> new BaseException(USERS_NOT_FOUND)
+        );
+
     }
 
 }

--- a/src/main/java/com/backend/simya/global/common/BaseResponse.java
+++ b/src/main/java/com/backend/simya/global/common/BaseResponse.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Map;
+
 import static com.backend.simya.global.common.BaseResponseStatus.SUCCESS;
 
 @Getter
@@ -39,4 +41,20 @@ public class BaseResponse<T> {
         this.code = status.getCode();
         this.message = status.getMessage();
     }
+
+    /**
+     * 형식적 Validation 용 Response
+     */
+    public BaseResponse(BaseResponseStatus status, T result) {
+        this.isSuccess = status.isSuccess();
+        this.code = status.getCode();
+        this.message = status.getMessage();
+        this.result = result;
+    }
+//    public BaseResponse(Map<String, String> result) {
+//        this.isSuccess = false;
+//        this.code = 400;
+//        this.message = "입력값을 확인해주세요.";
+//        this.result = (T) result;
+//    }
 }


### PR DESCRIPTION
### View를 보면서 필요한 로직 재검토 -> 기능 추가
- 카카오 로그인 시 프로필 생성
- 회원가입 시 프로필 닉네임만 받으면 바로 프로필 생성되도록 (→ 얘가 메인 프로필로 자동 지정됨)
- 대표 프로필로 지정되어 있던 프로필이 삭제되면 자동으로 대표 프로필 변경되도록

### 기타
- 예외처리 부분 일부 수정
- 응답, 요청 시 필요한 데이터 정리 (DTO 수정)
- 형식적 Validation 에 대한 응답 메서드 추가 (BaseResponse)

close #5 

