### PR TITLE
[ feat ] Header 값 수정

### DIFF
--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -52,6 +52,7 @@ public class UserController {
     public BaseResponse formLogin(@Valid @RequestBody LoginDto loginDto, HttpServletResponse response, Errors errors) {
 
         if (errors.hasErrors()) {
+            log.info("ValidError: {}", errors);
             ValidErrorDetails errorDetails = new ValidErrorDetails();
             return new BaseResponse<>(REQUEST_ERROR, errorDetails.validateHandling(errors));
         }
@@ -62,8 +63,8 @@ public class UserController {
             String refreshToken = tokenDto.getRefreshToken();
 
             // 헤더에 토큰 추가
-            response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Bearer " + accessToken);
-            response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Refresh  " + refreshToken);
+            response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Access " + accessToken);
+            response.addHeader(JwtFilter.REFRESH_HEADER, "Refresh  " + refreshToken);
 
             return new BaseResponse<>(tokenDto);
         } catch (BaseException e) {

--- a/src/main/java/com/backend/simya/domain/user/dto/request/LoginDto.java
+++ b/src/main/java/com/backend/simya/domain/user/dto/request/LoginDto.java
@@ -21,7 +21,7 @@ public class LoginDto {
     @Size(min = 3, max = 50)
     private String email;
 
-    @NotBlank(message = "비밀번호는 필수 입력 값입니다,")
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     @Size(min = 3, max = 100)
     private String password;
 }

--- a/src/main/java/com/backend/simya/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/simya/global/config/SecurityConfig.java
@@ -75,6 +75,13 @@ public class SecurityConfig {
                 .antMatchers("/", "/h2/**", "/simya/form-login", "/simya/auth", "/simya/form-signup", "/api/**").permitAll()
                 .anyRequest().authenticated()
 
+                // 로그아웃 설정
+                /*.and()
+                .logout()
+                .logoutUrl("simya/logout")
+                .invalidateHttpSession(true)
+                .deleteCookies("JSESSIONID")*/
+
                 .and()
                 .apply(new JwtSecurityConfig(tokenProvider));   // addFilterBefore로 등록했던 JwtSecurityConfig 클래스 적용 추가
 

--- a/src/main/java/com/backend/simya/global/config/jwt/JwtFilter.java
+++ b/src/main/java/com/backend/simya/global/config/jwt/JwtFilter.java
@@ -2,6 +2,7 @@ package com.backend.simya.global.config.jwt;
 
 import com.backend.simya.domain.jwt.service.TokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
@@ -25,13 +26,15 @@ import java.io.IOException;
  * 이때 DB 에 유저정보가 있는지 직접 조회한 것이 아니라 토큰에 실린 유저 정보를 조회한 것이므로, 탈퇴 등에 의해 DB에서 유저가 삭제된 경우는 Service 단에서 따로 고려를 해줘야 한다.
  *
  */
+@Slf4j
 @RequiredArgsConstructor
 public class JwtFilter extends GenericFilterBean {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtFilter.class);
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String AUTHORIZATION_HEADER = "Access-Token";
+    public static final String REFRESH_HEADER = "Refresh-Token";
+    public static final String BEARER_PREFIX = "Access ";
 
     private final TokenProvider tokenProvider;
 
@@ -62,7 +65,11 @@ public class JwtFilter extends GenericFilterBean {
     // 필터링을 하려면 토큰 정보 필요 -> Request Header에서 토큰 정보를 꺼내오는 메소드
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        log.info("request = {}", request.getHeader("Access-Token"));
+        log.info("request = {}", request.getHeader("Authorization"));
+        log.info("BearerToken - {}", bearerToken);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            log.info("StringUtils.hasText 실행 - {}", bearerToken.substring(7));
             return bearerToken.substring(7);
         }
         return null;

--- a/src/main/java/com/backend/simya/global/util/SecurityUtil.java
+++ b/src/main/java/com/backend/simya/global/util/SecurityUtil.java
@@ -15,7 +15,6 @@ public class SecurityUtil {
     private SecurityUtil() {}
 
     // Security Context의 Authentication 객체를 이용해 Username를 리턴해주는 간단한 유틸성 메소드
-    // TODO username(String) -> userId(Long) 로 변경
     public static Optional<String> getCurrentUsername() {
         /**
          * Security Context 에 Authentication 객체가 저장되는 시점은? JwtFilter 의 doFilter 메소드에서 Request 가 들어올 때

--- a/src/test/java/com/backend/simya/domain/profile/service/ProfileServiceTest.java
+++ b/src/test/java/com/backend/simya/domain/profile/service/ProfileServiceTest.java
@@ -1,0 +1,18 @@
+package com.backend.simya.domain.profile.service;
+
+import com.backend.simya.domain.profile.entity.Profile;
+import com.backend.simya.domain.profile.repository.ProfileRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class ProfileServiceTest {
+
+    @Autowired
+    ProfileRepository profileRepository;
+
+
+}


### PR DESCRIPTION
Header에 Access Token과 Refresh Token을 모두 실어서 보내기 위해 각각의 Key와 Value값을 수정하는 과정을 거쳤습니다.
기존에는 Authorizaion : "Bearer " + Access Token의 형식으로 헤더에 추가하여서 보냈다면,
변경된 이후는 <strong>Access-Token : "Access " + Access Token" / Refresh-Token : "Refresh " + Refresh Token </strong> 의 형태로 두 토큰 모두 실어주었습니다.

해당 내용은 포스트맨 테스트 시 중요하게 적용되니 노션 꼭 참고해주세요 !!!
 