### PR TITLE
[ Feat ] #23 api마무리1

### DIFF
--- a/src/main/java/com/backend/simya/domain/favorite/dto/MyFavoriteHouseResponseDto.java
+++ b/src/main/java/com/backend/simya/domain/favorite/dto/MyFavoriteHouseResponseDto.java
@@ -2,6 +2,7 @@ package com.backend.simya.domain.favorite.dto;
 
 import com.backend.simya.domain.favorite.entity.Favorite;
 import com.backend.simya.domain.house.dto.response.HouseIntroductionResponseDto;
+import com.backend.simya.domain.house.dto.response.HouseResponseDto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,15 +18,12 @@ import lombok.NoArgsConstructor;
 public class MyFavoriteHouseResponseDto {
 
     private Long favoriteId;
-    private HouseIntroductionResponseDto houseIntroduction;
+    private HouseResponseDto favoriteHouse;
 
     public static MyFavoriteHouseResponseDto from(Favorite favorite) {
         return MyFavoriteHouseResponseDto.builder()
                 .favoriteId(favorite.getFavoriteId())
-                .houseIntroduction(HouseIntroductionResponseDto.from(
-                        favorite.getHouse().getProfile(),
-                        favorite.getHouse(),
-                        favorite.getHouse().getReviewList()))
+                .favoriteHouse(HouseResponseDto.from(favorite.getHouse()))
                 .build();
     }
 }

--- a/src/main/java/com/backend/simya/domain/favorite/entity/Favorite.java
+++ b/src/main/java/com/backend/simya/domain/favorite/entity/Favorite.java
@@ -36,22 +36,11 @@ public class Favorite extends BaseTimeEntity {
     @JsonBackReference
     private House house;
 
-    @Column(name = "activated")
-    private boolean activated;
-
     public void setProfile(Profile profile) {
         this.profile = profile;
     }
 
     public void setHouse(House house) {
         this.house = house;
-    }
-
-    public boolean isActivated() {
-        return this.activated;
-    }
-
-    public void changeStatus(boolean activated) {
-        this.activated = activated;
     }
 }

--- a/src/main/java/com/backend/simya/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/backend/simya/domain/favorite/service/FavoriteService.java
@@ -31,7 +31,6 @@ public class FavoriteService {
         Favorite newFavorite = Favorite.builder()
                 .profile(mainProfile)
                 .house(houseToRegisterFavorite)
-                .activated(true)
                 .build();
         Favorite registeredFavorite = favoriteRepository.save(newFavorite);
         mainProfile.addFavorite(registeredFavorite);
@@ -41,22 +40,18 @@ public class FavoriteService {
     @Transactional
     public void cancelFavorite(Long favoriteId) throws BaseException {
         Favorite favoriteToCancel = findFavorite(favoriteId);
-        favoriteToCancel.changeStatus(false);
-        favoriteToCancel.getProfile().removeFavorite(favoriteToCancel);
-        favoriteToCancel.getHouse().removeFavorite(favoriteToCancel);
+        favoriteRepository.delete(favoriteToCancel);
     }
 
     public List<MyFavoriteHouseResponseDto> findCurrentProfileFavoriteHouses(User currentUser) {
         Profile mainProfile = currentUser.getProfileList().get(currentUser.getMainProfile());
         return favoriteRepository.findFavoriteListByProfileId(mainProfile.getProfileId()).stream()
-                .filter(Favorite::isActivated)
                 .map(MyFavoriteHouseResponseDto::from)
                 .collect(Collectors.toList());
     }
 
     public List<ProfileResponseDto> findProfilesLikeMyHouse(House house) {
         return favoriteRepository.findFavoriteListByHouseId(house.getHouseId()).stream()
-                .filter(Favorite::isActivated)
                 .map(Favorite::getProfile)
                 .map(ProfileResponseDto::from)
                 .collect(Collectors.toList());
@@ -66,5 +61,4 @@ public class FavoriteService {
         return favoriteRepository.findById(favoriteId)
                 .orElseThrow(() -> new BaseException(FAILED_TO_FIND_FAVORITE));
     }
-
 }

--- a/src/main/java/com/backend/simya/domain/house/dto/request/HouseOpenRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/house/dto/request/HouseOpenRequestDto.java
@@ -1,6 +1,7 @@
 package com.backend.simya.domain.house.dto.request;
 
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Data

--- a/src/main/java/com/backend/simya/domain/house/dto/request/HouseUpdateRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/house/dto/request/HouseUpdateRequestDto.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class HouseUpdateRequestDto {
-    private Long houseId;
+    
     private String signboardImageUrl;
     private String houseName;
     private String comment;

--- a/src/main/java/com/backend/simya/domain/house/dto/request/NewHouseRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/house/dto/request/NewHouseRequestDto.java
@@ -25,7 +25,6 @@ public class NewHouseRequestDto {
                 .capacity(0)
                 .signboardImageUrl(signboardImageUrl)
                 .open(false)
-                .activated(true)
                 .build();
     }
 }

--- a/src/main/java/com/backend/simya/domain/house/dto/request/TopicRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/house/dto/request/TopicRequestDto.java
@@ -18,11 +18,11 @@ public class TopicRequestDto {
     private String title;
     private String content;
 
-    public Topic toEntity(House house) {
+    public Topic toEntity(House house, boolean isMain) {
         return Topic.builder()
-                .title(this.title)
-                .content(this.content)
-                .isTodayTopic(false)
+                .title(this.getTitle())
+                .content(this.getContent())
+                .isTodayTopic(isMain)
                 .house(house)
                 .build();
     }

--- a/src/main/java/com/backend/simya/domain/house/dto/response/HouseIntroductionResponseDto.java
+++ b/src/main/java/com/backend/simya/domain/house/dto/response/HouseIntroductionResponseDto.java
@@ -31,7 +31,6 @@ public class HouseIntroductionResponseDto {
                 .masterProfile(ProfileResponseDto.from(profile))
                 .houseInfo(HouseResponseDto.from(house))
                 .houseReviewList(reviewList.stream()
-                        .filter(Review::isActivated)
                         .map(ReviewResponseDto::from)
                         .collect(Collectors.toList()))
                 .build();

--- a/src/main/java/com/backend/simya/domain/house/dto/response/HouseResponseDto.java
+++ b/src/main/java/com/backend/simya/domain/house/dto/response/HouseResponseDto.java
@@ -24,7 +24,8 @@ public class HouseResponseDto {
         return HouseResponseDto.builder()
                 .houseId(house.getHouseId())
                 .houseName(house.getHouseName())
-                .category(house.getCategory().toString())
+                .category(house.getCategory().getName())
+                .signboardImageUrl(house.getSignboardImageUrl())
                 .comment(house.getComment())
                 .build();
     }

--- a/src/main/java/com/backend/simya/domain/house/dto/response/HouseSignboardResponseDto.java
+++ b/src/main/java/com/backend/simya/domain/house/dto/response/HouseSignboardResponseDto.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 public class HouseSignboardResponseDto {
 
     private Long houseId;
-    private Category category;
+    private String category;
     private String signboardImageUrl;
     private String houseName;
     private String todayTopicTitle;
@@ -28,7 +28,7 @@ public class HouseSignboardResponseDto {
     public static HouseSignboardResponseDto from(House house, String todayTopicTitle) {
         return HouseSignboardResponseDto.builder()
                 .houseId(house.getHouseId())
-                .category(house.getCategory())
+                .category(house.getCategory().getName())
                 .signboardImageUrl(house.getSignboardImageUrl())
                 .houseName(house.getHouseName())
                 .todayTopicTitle(todayTopicTitle)

--- a/src/main/java/com/backend/simya/domain/house/entity/House.java
+++ b/src/main/java/com/backend/simya/domain/house/entity/House.java
@@ -70,15 +70,17 @@ public class House extends BaseTimeEntity {
     @Column(name = "open")
     private boolean open;  // 오픈 상태인지
 
-    @Column(name = "activated")
-    private boolean activated;
-
     public void openHouse(int capacity) {
         this.open = true;
         this.capacity = capacity;
     }
 
-    public House update(HouseUpdateRequestDto houseUpdateRequestDto) {
+    public void closeHouse() {
+        this.open = false;
+        this.capacity = 0;
+    }
+
+    public House updateSignboard(HouseUpdateRequestDto houseUpdateRequestDto) {
         this.signboardImageUrl = houseUpdateRequestDto.getSignboardImageUrl();
         this.houseName = houseUpdateRequestDto.getHouseName();
         this.comment = houseUpdateRequestDto.getComment();
@@ -86,32 +88,26 @@ public class House extends BaseTimeEntity {
         return this;
     }
 
-    public void delete() {
-        this.activated = false;
-    }
-
     public void addReview(Review review) {
         reviewList.add(review);
         review.setReviewedHouse(this);
     }
-
-    public void removeReview(Review review) {
-        reviewList.remove(review);
-    }
-
 
     public void addFavorite(Favorite favorite) {
         favoriteList.add(favorite);
         favorite.setHouse(this);
     }
 
-    public void removeFavorite(Favorite favorite) {
-        favoriteList.remove(favorite);
-    }
-
     public void addTopic(Topic topic) {
         topicList.add(topic);
-        topic.setHouseToRegisterTopic(this);
+        //topic.setHouseToRegisterTopic(this);
     }
 
+    public void deleteTopic(Topic topic) {
+        topicList.remove(topic);
+    }
+
+    public void deleteAllTopic() {
+        topicList.clear();
+    }
 }

--- a/src/main/java/com/backend/simya/domain/house/entity/Topic.java
+++ b/src/main/java/com/backend/simya/domain/house/entity/Topic.java
@@ -34,9 +34,6 @@ public class Topic extends BaseTimeEntity {
     @Column(name = "is_today_topic")
     private boolean isTodayTopic;
 
-    @Column(name = "activated")
-    private boolean activated;
-
     public boolean isTodayTopic() {
         return this.isTodayTopic;
     }

--- a/src/main/java/com/backend/simya/domain/house/repository/HouseRepository.java
+++ b/src/main/java/com/backend/simya/domain/house/repository/HouseRepository.java
@@ -1,7 +1,6 @@
 package com.backend.simya.domain.house.repository;
 
 import com.backend.simya.domain.house.entity.House;
-import com.backend.simya.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -13,5 +12,4 @@ public interface HouseRepository extends JpaRepository<House, Long> {
             "from Review house " +
             "where house.profile.user.userId = :userId")
     List<House> findMyHousesByUserId(Long userId);
-
 }

--- a/src/main/java/com/backend/simya/domain/house/service/HouseService.java
+++ b/src/main/java/com/backend/simya/domain/house/service/HouseService.java
@@ -33,20 +33,15 @@ import static com.backend.simya.global.common.BaseResponseStatus.*;
 public class HouseService {
 
     private final HouseRepository houseRepository;
-    private final ProfileService profileService;
     private final TopicService topicService;
-    private final ReviewService reviewService;
 
 
     // 새 이야기 집 생성
     @Transactional
-    public HouseResponseDto createHouse(NewHouseRequestDto newHouseRequestDto) throws BaseException {
+    public HouseResponseDto createHouse(Profile masterProfile, NewHouseRequestDto newHouseRequestDto) throws BaseException {
         try {
-            Profile findProfile = profileService.findProfile(newHouseRequestDto.getProfileId());  // 해당하는 프로필 찾기
-            House savedHouse = houseRepository.save(newHouseRequestDto.toEntity(findProfile));
+            House savedHouse = houseRepository.save(newHouseRequestDto.toEntity(masterProfile));
             return HouseResponseDto.from(savedHouse);
-        } catch (BaseException e) {
-            throw new BaseException(e.getStatus());
         } catch (Exception ignored) {
             throw new BaseException(DATABASE_ERROR);
         }
@@ -56,6 +51,7 @@ public class HouseService {
     @Transactional
     public HouseSignboardResponseDto openHouse(User loginUser, HouseOpenRequestDto houseOpenRequestDto) throws BaseException {
         House houseToOpen = findHouse(houseOpenRequestDto.getHouseId());
+        Topic todayTopic = houseOpenRequestDto.getTopic().toEntity(houseToOpen, true);
         if (!loginUser.getUserId().equals(houseToOpen.getProfile().getProfileId())) { // 이야기 집 생성자가 오픈하려는지 확인
             throw new BaseException(FAILED_TO_OPEN);
         } else if (houseToOpen.isOpen()) {  // 이미 오픈된 이야기 집인 경우
@@ -63,14 +59,13 @@ public class HouseService {
         } else {
             try {
                 houseToOpen.openHouse(houseOpenRequestDto.getCapacity());
-                return HouseSignboardResponseDto.from(houseToOpen,registerTopic(houseToOpen, houseOpenRequestDto.getTopic()).getTitle()) ;
+                return HouseSignboardResponseDto.from(houseToOpen,registerNewTopic(houseToOpen, todayTopic).getTitle()) ;
             } catch (Exception ignored) {
                 throw new BaseException(HOUSE_OPEN_FAILED);
             }
         }
     }
 
-    //
     public House findHouse(Long houseId) throws BaseException {
         return houseRepository.findById(houseId).orElseThrow(
                 () -> new BaseException(HOUSE_NOT_FOUND)
@@ -78,94 +73,97 @@ public class HouseService {
     }
 
     @Transactional(readOnly = true)
-    public HouseIntroductionResponseDto showHouse(Long houseId) throws BaseException {
+    public HouseIntroductionResponseDto getHouseIntroduction(House findHouse, Profile masterProfile, List<Review> reviewList) throws BaseException {
         try {
-            House house = findHouse(houseId);
-            Profile profileInfo = profileService.findProfile(house.getProfile().getProfileId());
-            List<Review> reviewList = reviewService.getReviewList(house);
-            return HouseIntroductionResponseDto.from(profileInfo, house, reviewList);
-
+            return HouseIntroductionResponseDto.from(masterProfile, findHouse, reviewList);
         } catch (Exception ignored) {
             throw new BaseException(DATABASE_ERROR);
         }
     }
 
     @Transactional
-    public void updateMain(User loginUser, HouseUpdateRequestDto houseUpdateRequestDto) throws BaseException {
-        House findHouse = findHouse(houseUpdateRequestDto.getHouseId());
+    public HouseResponseDto updateSignboard(User loginUser, Long houseId, HouseUpdateRequestDto houseUpdateRequestDto) throws BaseException {
+        House findHouse = findHouse(houseId);
         if (!loginUser.getUserId().equals(findHouse.getProfile().getProfileId())) {  // 이야기 집 생성자가 수정하려는지 확인
             throw new BaseException(FAILED_TO_UPDATE);
         }
         try {
-            findHouse.update(houseUpdateRequestDto);
-            log.info("{}의 이야기 집 간판이 수정되었습니다.", findHouse.getHouseName());
-
+            return HouseResponseDto.from(findHouse.updateSignboard(houseUpdateRequestDto));
         } catch (Exception ignored) {
             throw new BaseException(HOUSE_UPDATE_FAILED);
         }
     }
 
     @Transactional
-    public void closeHouseRoom(User loginUser, Long houseId) throws BaseException {
-        House house = findHouse(houseId);
-        if (!loginUser.getUserId().equals(house.getProfile().getProfileId())) {
+    public void deleteHouse(User loginUser, Long houseId) throws BaseException {
+        House houseToDelete = findHouse(houseId);
+        if (!loginUser.getUserId().equals(houseToDelete.getProfile().getProfileId())) {
             throw new BaseException(FAILED_TO_CLOSE);
-        }
-
-        try {
-            house.delete();
-            log.info("{}의 이야기 집이 폐점되었습니다.", house.getHouseName());
-
-            topicService.deleteAllTopic(house.getHouseId());  // 해당 이야기집의 topic 모두 삭제
-
-        }catch (Exception ignored) {
-            throw new BaseException(FAILED_TO_OPEN_HOUSE);
-        }
-
-    }
-
-    public List<HouseSignboardResponseDto> findAllHouseSignBoard() throws BaseException{
-
-        List<House> OpenedHouses = houseRepository.findAll().stream()
-                .filter(House::isActivated)
-                .filter(House::isOpen)
-                .collect(Collectors.toList());
-
-        if(OpenedHouses.isEmpty()){
-            throw new BaseException(NO_HOUSE_YET);
         } else {
-            return OpenedHouses.stream()
-                    .map(house -> HouseSignboardResponseDto.from(house, house.getTopicList().stream()
-                            .filter(Topic::isTodayTopic)
-                            .findFirst()
-                            .get()
-                            .getTitle()))
-                    .collect(Collectors.toList());
+            houseRepository.delete(houseToDelete);
         }
     }
 
-    public List<HouseResponseDto> findMyHouses(Long currentUserId) {
+    public List<HouseSignboardResponseDto> getAllHouseSignboard() throws BaseException {
+
+        List<House> allHouse = houseRepository.findAll();
+        if(allHouse.isEmpty()){
+           throw new BaseException(NO_HOUSE_YET);
+        } else {
+            List<House> openedHouses = allHouse.stream()
+                    .filter(House::isOpen)
+                    .collect(Collectors.toList());
+            if (openedHouses.isEmpty()) {
+                throw new BaseException(NO_OPENED_HOUSE_YET);
+            } else {
+                return openedHouses.stream()
+                        .map(house -> HouseSignboardResponseDto.from(house, house.getTopicList().stream()
+                                .filter(Topic::isTodayTopic)
+                                .findFirst()
+                                .get()
+                                .getTitle()))
+                        .collect(Collectors.toList());
+            }
+        }
+    }
+
+    public List<HouseResponseDto> getMyHouses(Long currentUserId) {
 
         return houseRepository.findMyHousesByUserId(currentUserId).stream()
-                .filter(House::isActivated)
                 .filter(House::isOpen)
                 .map(HouseResponseDto::from)
                 .collect(Collectors.toList());
     }
 
-    public List<TopicResponseDto> findHousesTopic(Long houseId) {
+    public List<TopicResponseDto> getHousesTopic(Long houseId) {
 
         return topicService.findAllTopic(houseId).stream()
-                .filter(Topic::isActivated)
                 .map(TopicResponseDto::from)
                 .collect(Collectors.toList());
     }
 
     @Transactional
-    public TopicResponseDto registerTopic(House houseToRegisterTopic, TopicRequestDto topicToRegisterDto) throws BaseException {
-        Topic newTopic = topicService.createTopic(houseToRegisterTopic, topicToRegisterDto);
-        houseToRegisterTopic.addTopic(newTopic);
+    public TopicResponseDto registerNewTopic(House houseToRegisterTopic, Topic topicToRegister) throws BaseException {
+        log.info("service - regisgerNewTopic {}", topicToRegister.getTitle());
+        houseToRegisterTopic.addTopic(topicToRegister);
+        Topic newTopic = topicService.createTopic(topicToRegister);
         return TopicResponseDto.from(newTopic);
     }
 
+    @Transactional
+    public void closeHouse(Long houseId) throws BaseException {
+        House houseToClose = findHouse(houseId);
+        houseToClose.closeHouse();
+        deleteAllTopicInHouse(houseToClose);
+    }
+
+    @Transactional
+    public void deleteTopicInHouse(House myHouse, Topic topicToDelete) {
+        myHouse.deleteTopic(topicToDelete);
+    }
+
+    @Transactional
+    public void deleteAllTopicInHouse(House myHouse) {
+        myHouse.deleteAllTopic();
+    }
 }

--- a/src/main/java/com/backend/simya/domain/house/service/TopicService.java
+++ b/src/main/java/com/backend/simya/domain/house/service/TopicService.java
@@ -1,6 +1,5 @@
 package com.backend.simya.domain.house.service;
 
-import com.backend.simya.domain.house.dto.request.TopicRequestDto;
 import com.backend.simya.domain.house.entity.House;
 import com.backend.simya.domain.house.entity.Topic;
 import com.backend.simya.domain.house.repository.TopicRepository;
@@ -12,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.backend.simya.global.common.BaseResponseStatus.DATABASE_ERROR;
 import static com.backend.simya.global.common.BaseResponseStatus.FAILED_TO_CREATE_TOPIC;
 
 @Slf4j
@@ -22,10 +22,10 @@ public class TopicService {
     private final TopicRepository topicRepository;
 
     @Transactional
-    public Topic createTopic(House houseToRegisterTopic, TopicRequestDto topicToRegisterRequestDto) throws BaseException {
+    public Topic createTopic(Topic topicToRegister) throws BaseException {
         try {
-            Topic newTopic = topicToRegisterRequestDto.toEntity(houseToRegisterTopic);
-            return topicRepository.save(newTopic);
+            log.info("TopicService - topicToRegister {}", topicToRegister.getTitle());
+            return topicRepository.save(topicToRegister);
         } catch (Exception ignored) {
             throw new BaseException(FAILED_TO_CREATE_TOPIC);
         }
@@ -36,10 +36,8 @@ public class TopicService {
         return topicRepository.findAllByHouseId(houseId);
     }
 
-    @Transactional
-    public void deleteAllTopic(Long houseId) {
-        List<Topic> allTopic = findAllTopic(houseId);
-        topicRepository.deleteAll(allTopic);
+    public Topic findTopic(Long topicId) throws BaseException {
+        return topicRepository.findById(topicId)
+                .orElseThrow(() -> new BaseException(DATABASE_ERROR));
     }
-
 }

--- a/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/profile/dto/request/ProfileRequestDto.java
@@ -38,7 +38,6 @@ public class ProfileRequestDto {
                 .picture(picture)
                 .user(null)
                 .isRepresent(false)
-                .activated(true)
                 .build();
     }
 

--- a/src/main/java/com/backend/simya/domain/profile/entity/Profile.java
+++ b/src/main/java/com/backend/simya/domain/profile/entity/Profile.java
@@ -61,15 +61,10 @@ public class Profile extends BaseTimeEntity {
     @Column(name = "is_represent")
     private boolean isRepresent;
 
-    @Column(name = "activated")
-    private boolean activated;
-
-
     @Builder.Default
     @OneToMany(mappedBy = "profile", cascade = ALL, orphanRemoval = true)
     @JsonManagedReference
     private List<House> houseList = new ArrayList<>();
-
 
     public void selectMainProfile() {
         this.isRepresent = true;
@@ -96,11 +91,6 @@ public class Profile extends BaseTimeEntity {
         return this;
     }
 
-    public Profile delete(Long profileId) {
-        this.activated = false;
-        return this;
-    }
-
     public void addReview(Review review) {
         reviewList.add(review);
         review.setReviewersProfile(this);
@@ -113,5 +103,9 @@ public class Profile extends BaseTimeEntity {
 
     public void removeFavorite(Favorite favorite) {
         favoriteList.remove(favorite);
+    }
+
+    public void removeReview(Review review) {
+        reviewList.remove(review);
     }
 }

--- a/src/main/java/com/backend/simya/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/backend/simya/domain/profile/service/ProfileService.java
@@ -1,11 +1,13 @@
 package com.backend.simya.domain.profile.service;
 
 
+import com.backend.simya.domain.favorite.entity.Favorite;
 import com.backend.simya.domain.profile.dto.request.ProfileRequestDto;
 import com.backend.simya.domain.profile.dto.request.ProfileUpdateDto;
 import com.backend.simya.domain.profile.dto.response.ProfileResponseDto;
 import com.backend.simya.domain.profile.entity.Profile;
 import com.backend.simya.domain.profile.repository.ProfileRepository;
+import com.backend.simya.domain.review.entity.Review;
 import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.global.common.BaseException;
 import lombok.RequiredArgsConstructor;
@@ -83,19 +85,16 @@ public class ProfileService {
     @Transactional
     public void deleteProfile(Long profileId) throws BaseException {
         try {
-            Profile profile = findProfile(profileId);
-            boolean isMain = profile.isRepresent();
-            if (profile.isActivated()) {
-                if (profile.getUser().getProfileList().isEmpty()) {
-                    throw new BaseException(USERS_NEED_ONE_MORE_PROFILE);
-                }
-                profile.delete(profileId);
-
-                if (isMain) {
-                    profile.autoSetMainProfile();
-                }
+            Profile profileToDelete = findProfile(profileId);
+            boolean isMain = profileToDelete.isRepresent();
+            if (profileToDelete.getUser().getProfileList().isEmpty()) {
+                throw new BaseException(USERS_NEED_ONE_MORE_PROFILE);
             } else {
-                throw new BaseException(ALREADY_DELETE_PROFILE);
+                if (isMain) {
+                    profileToDelete.autoSetMainProfile();
+                } else {
+                    profileRepository.delete(profileToDelete);
+                }
             }
         } catch (Exception ignored) {
             throw new BaseException(DELETE_FAIL_PROFILE);
@@ -108,4 +107,13 @@ public class ProfileService {
         );
     }
 
+    @Transactional
+    public void deleteReview(Profile currentProfile, Review review) {
+        currentProfile.removeReview(review);
+    }
+
+    @Transactional
+    public void deleteFavorite(Profile currentProfile, Favorite favorite) {
+        currentProfile.removeFavorite(favorite);
+    }
 }

--- a/src/main/java/com/backend/simya/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/backend/simya/domain/review/controller/ReviewController.java
@@ -30,6 +30,7 @@ public class ReviewController {
     private final UserService userService;
     private final HouseService houseService;
 
+
     @PostMapping("/{house-id}")
     public BaseResponse<ReviewResponseDto> postReview(@PathVariable("house-id") Long houseId,
                                                       @RequestBody ReviewRequestDto reviewRequestDto) {
@@ -86,11 +87,25 @@ public class ReviewController {
         }
     }
 
-    @PatchMapping("/{review-id}/delete")
+    @PatchMapping("/delete/{review-id}")
     public BaseResponse<BaseResponseStatus> deleteReview(@PathVariable("review-id") Long reviewId) {
         try {
             reviewService.deleteReview(reviewId);
             return new BaseResponse<>(SUCCESS_TO_DELETE_REVIEW);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    @GetMapping("/check/{house-id}")
+    public BaseResponse<BaseResponseStatus> checkReviewedHouse(@PathVariable("house-id") Long houseId) {
+        try {
+            Long currentUserId = userService.getMyUserWithAuthorities().getUserId();
+            if (reviewService.isReviewedHouse(currentUserId, houseId)) {
+                return new BaseResponse<>(HAVE_REVIEWED_BEFORE);
+            } else {
+                return new BaseResponse<>(NEVER_REVIEWED_BEFORE);
+            }
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/com/backend/simya/domain/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/backend/simya/domain/review/dto/ReviewRequestDto.java
@@ -23,7 +23,6 @@ public class ReviewRequestDto {
                 .profile(profile)
                 .rate(this.rate)
                 .content(this.content)
-                .activated(true)
                 .build();
     }
 }

--- a/src/main/java/com/backend/simya/domain/review/entity/Review.java
+++ b/src/main/java/com/backend/simya/domain/review/entity/Review.java
@@ -44,10 +44,7 @@ public class Review extends BaseTimeEntity {
     @Column(name = "content")
     private String content;
 
-    @Column(name = "activated")
-    private boolean activated;
-
-    public void setReviewersProfile (Profile profile) {
+    public void setReviewersProfile(Profile profile) {
         this.profile = profile;
     }
 
@@ -61,10 +58,6 @@ public class Review extends BaseTimeEntity {
 
     public void setContent(String content) {
         this.content = content;
-    }
-
-    public void changeStatus(boolean activated) {
-        this.activated = activated;
     }
 
     public Review updateReview(int rate, String content) {

--- a/src/main/java/com/backend/simya/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/backend/simya/domain/review/repository/ReviewRepository.java
@@ -14,12 +14,15 @@ import java.util.Optional;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-
      @Query(value = "select review " +
              "from Review review " +
              "where review.profile.profileId = :profileId")
      List<Review> findReviewsByProfileId(Long profileId);
 
+     @Query(value = "select review " +
+             "from Review review " +
+             "where review.profile.user.userId = :userId AND review.house.houseId = :houseId")
+     List<Review> findReviewsByUserIdAndHouseId(Long userId, Long houseId);
 
      List<Review> findReviewsByHouse(House house);
 }

--- a/src/main/java/com/backend/simya/domain/review/service/ReviewService.java
+++ b/src/main/java/com/backend/simya/domain/review/service/ReviewService.java
@@ -48,7 +48,6 @@ public class ReviewService {
 
     public List<ReviewResponseDto> getHouseReviewList(House house) {
         return reviewRepository.findReviewsByHouse(house).stream()
-                .filter(Review::isActivated)
                 .map(ReviewResponseDto::from)
                 .collect(Collectors.toList());
     }
@@ -60,7 +59,6 @@ public class ReviewService {
     public List<MyReviewResponseDto> getCurrentProfileReviewList(User currentUser) {
         return reviewRepository.findReviewsByProfileId(currentUser.getProfileList()
                         .get(currentUser.getMainProfile()).getProfileId()).stream()
-                .filter(Review::isActivated)
                 .map(review -> MyReviewResponseDto.from(review.getHouse(), review))
                 .collect(Collectors.toList());
     }
@@ -68,7 +66,7 @@ public class ReviewService {
     @Transactional
     public void deleteReview(Long reviewId) throws BaseException {
         Review findReview = findReview(reviewId);
-        findReview.changeStatus(false);
+        reviewRepository.delete(findReview);
     }
 
     @Transactional
@@ -82,5 +80,9 @@ public class ReviewService {
     private Review findReview(Long reviewId) throws BaseException {
         return reviewRepository.findById(reviewId).
                 orElseThrow(() -> new BaseException(FAILED_TO_FIND_REVIEW));
+    }
+
+    public boolean isReviewedHouse(Long currentUserId, Long houseId) {
+        return !reviewRepository.findReviewsByUserIdAndHouseId(currentUserId, houseId).isEmpty();
     }
 }

--- a/src/main/java/com/backend/simya/domain/user/entity/User.java
+++ b/src/main/java/com/backend/simya/domain/user/entity/User.java
@@ -128,7 +128,7 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     public int getMainProfile() {
         for (int i=0; i<profileList.size(); i++) {
-            if (profileList.get(i).isRepresent() && profileList.get(i).isActivated()) {
+            if (profileList.get(i).isRepresent()) {
                 return i;
             }
         }

--- a/src/main/java/com/backend/simya/domain/user/service/OauthService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/OauthService.java
@@ -152,7 +152,6 @@ public class OauthService {
                 .comment(null)
                 .picture(null)
                 .isRepresent(true)
-                .activated(true)
                 .build();
         newKakaoUser.addProfile(mainProfile);
         profileRepository.save(mainProfile);

--- a/src/main/java/com/backend/simya/domain/user/service/UserService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/UserService.java
@@ -50,7 +50,6 @@ public class UserService {
                     .comment(userDto.getProfile().getComment())
                     .picture(userDto.getProfile().getPicture())
                     .isRepresent(true)
-                    .activated(true)
                     .build();
             newUser.addProfile(mainProfile);
             profileRepository.save(mainProfile);

--- a/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
+++ b/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
@@ -10,13 +10,24 @@ import lombok.Getter;
 public enum BaseResponseStatus {
 
     // 200 ~ : 성공
-    SUCCESS(true, 200, "요청에 성공하였습니다."),
-    SUCCESS_TO_UPDATE_REVIEW(true, 200, "리뷰 업데이트에 성공하였습니다"),
-    SUCCESS_TO_DELETE_REVIEW(true, 200, "리뷰 삭제에 성공하였습니다."),
-    SUCCESS_TO_REGISTER_FAVORITE(true, 200, "찜 등록에 성공하였습니다."),
-    SUCCESS_TO_CANCEL_FAVORITE(true, 200, "찜 해제에 성공하였습니다."),
-    NO_HOUSE_YET(true, 200, "아직 오픈한 이야기 집이 없습니다."),
+    SUCCESS(true, 200, "요청에 성공했습니다."),
+    SUCCESS_TO_UPDATE_REVIEW(true, 200, "리뷰 업데이트에 성공했습니다"),
+    SUCCESS_TO_DELETE_REVIEW(true, 200, "리뷰 삭제에 성공했습니다."),
+    SUCCESS_TO_REGISTER_FAVORITE(true, 200, "찜 등록에 성공했습니다."),
+    SUCCESS_TO_CANCEL_FAVORITE(true, 200, "찜 해제에 성공했습니다."),
+    NO_OPENED_HOUSE_YET(true, 200, "아직 오픈한 이야기 집이 없습니다."),
+    NO_HOUSE_YET(true, 200, "이야기 집이 없습니다."),
     NO_REVIEWS_YET(true, 200, "아직 리뷰가 없습니다"),
+    SUCCESS_TO_DELETE_TOPIC(true, 200, "오늘의 메뉴 삭제에 성공했습니다"),
+    SUCCESS_TO_CLOSE_HOUSE(true, 200, "이야기 집을 마감했습니다"),
+    SUCCESS_TO_DELETE_HOUSE(true, 200, "이야기 집을 폐점했습니다"),
+    SUCCESS_TO_UPDATE_HOUSE_SIGNBOARD(true, 200, "이야기 집 간판을 수정했습니다."),
+    NEVER_REVIEWED_BEFORE(true, 200, "리뷰를 쓴 적이 없는 유저입니다."),
+    HAVE_REVIEWED_BEFORE(true, 200, "리뷰를 쓴 적이 있는 유저입니다."),
+
+
+
+
 
 
     // 400 ~ :  클라이언트 Request 오류


### PR DESCRIPTION
이야기 집 채팅과 오늘의 메뉴 선정 API를 제외한 API 개발과 검증이 끝났습니다
세부내용으론

1. activated의 개념이 아닌 실제 delete를 적용함에 따라 cascade ALL과 orphanremoval true를 효과적으로 사용할 수 있어 하위 엔티티들의 관리가 편해졌다
2. 순환참조가 생겼기 때문에, 가능한 Service에서 Service주입을 지양하고자 Controller에서 Service를 주로 사용한다
3. 등등 API개발과, 리팩토링

이 주로 이뤄졌고 추후 채팅방을 제외하고 해야할 일들은

1. 디테일한 예외처리 구현
2. URL 설계 리팩토링
3. 네이밍 다듬기
4. 사진첨부
5. 오늘의 메뉴 선정
6. 포스트맨에 저장된 Response를 보고 성공 API명세 우선 작성

등등이 있습니다 이따 또 뵙고 이야기 나눠봅시다!