### PR TITLE
[ Feat ] 회원탈퇴 API 추가, URI 및 컨트롤러 매핑 수정

### DIFF
--- a/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
+++ b/src/main/java/com/backend/simya/domain/profile/controller/ProfileController.java
@@ -63,7 +63,7 @@ public class ProfileController {
         }
     }
 
-    @PatchMapping("/{profileId}/delete")
+    @DeleteMapping("/{profileId}/delete")
     public BaseResponse<String> deleteProfile(@PathVariable("profileId") Long profileId) {
 
         try {

--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import static com.backend.simya.global.common.BaseResponseStatus.REQUEST_ERROR;
+import static com.backend.simya.global.common.BaseResponseStatus.SUCCESS_TO_WITHDRAW;
 
 @Slf4j
 @RestController
@@ -93,5 +94,16 @@ public class UserController {
             return new BaseResponse<>(e.getStatus());
         }
 
+    }
+
+    @DeleteMapping("/withdraw")
+    public BaseResponse withdraw() {
+        try {
+            User loginUser = userService.getMyUserWithAuthorities();
+            userService.withdraw(loginUser.getUserId());
+            return new BaseResponse(SUCCESS_TO_WITHDRAW);
+        } catch (BaseException e) {
+            return new BaseResponse(e.getStatus());
+        }
     }
 }

--- a/src/main/java/com/backend/simya/domain/user/service/UserService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/UserService.java
@@ -88,4 +88,13 @@ public class UserService {
 
     }
 
+    @Transactional
+    public void withdraw(Long userId) throws BaseException {
+        try {
+            userRepository.deleteById(userId);
+        } catch (Exception exception) {
+            throw new BaseException(DELETE_FAIL_USER);
+        }
+    }
+
 }

--- a/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
+++ b/src/main/java/com/backend/simya/global/common/BaseResponseStatus.java
@@ -26,6 +26,7 @@ public enum BaseResponseStatus {
     HAVE_REVIEWED_BEFORE(true, 200, "리뷰를 쓴 적이 있는 유저입니다."),
     SUCCESS_TO_UPDATE_CATEGORY(true, 200, "이야기 집의 전문메뉴를 수정했습니다."),
 
+    SUCCESS_TO_WITHDRAW(true, 200, "회원탈퇴에 성공했습니다."),
 
 
 
@@ -89,6 +90,7 @@ public enum BaseResponseStatus {
 
     GET_FAIL_USERINFO(false, 500, "회원정보 조회에 실패했습니다"),
     POST_FAIL_USER(false, 500, "회원가입에 실패했습니다."),
+    DELETE_FAIL_USER(false, 500, "회원탈퇴에 실패했습니다."),
 
     // [PATCH] user 정보 수정 시
     MODIFY_FAIL_USERNAME(false, 500, "회원 이름을 변경하는 데 실패했습니다."),


### PR DESCRIPTION
기존에 activated 필드로 관리했던 테이블을 삭제하는 방식으로 바꾸면서 컨트롤러의 @PatchMapping -> @DeleteMapping 으로 수정하는 과정을 거쳤습니다. 또한, 현재 접속한 유저가 회원탈퇴를 하도록 userId 값을 넘겨주는 PathVariable 방식 대신 별도의 파라미터를 컨트롤러에서 필요로 하지 않도록 API를 추가했습니다. 

close #28 