### PR TITLE
[ Feat ] websocket header

### DIFF
--- a/src/main/java/com/backend/simya/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/backend/simya/domain/chat/controller/ChatController.java
@@ -29,10 +29,10 @@ import org.springframework.stereotype.Controller;
 public class ChatController {
 
     private final AuthService authService;
+    private final UserService userService;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatService chatService;
     private final TokenProvider tokenProvider;
-    private final UserRepository userRepository;
 
     /**
      * WebSocket "/pub/chat/message" 로 들어오는 메시징 처리
@@ -43,17 +43,17 @@ public class ChatController {
         try {
             log.info("Web Socket Header 에서 읽어온 Access-Token: {}", token);
             String authenticateUser = tokenProvider.getAuthentication(token).getName();
-            Profile profile = null;
+            String profile = "X";
 
             try {
                 log.info("ChatController - Authenticate User : {}", authenticateUser);
-                profile = chatService.getSessionToMainProfile(authenticateUser);
+                profile = userService.getSessionToMainProfile(authenticateUser).getNickname();
             } catch (LazyInitializationException | BaseException e) {
                 log.error("유저와 대표 프로필 조회에 실패했습니다.");
             }
             log.info("@MessageMapping - authenticateUser: {} => nickname: {}", authenticateUser, profile);
 
-            message.setSender(profile.getNickname());         // 로그인 회원 정보로 대화명 설정
+            message.setSender(profile);         // 로그인 회원 정보로 대화명 설정
             message.setUserCount(chatRoomRepository.getUserCount(message.getRoomId()));  // 채팅방 인원 수 세팅
 
             // WebSocket 에 발행된 메시지를 Redis 로 발행(publish)s

--- a/src/main/java/com/backend/simya/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/backend/simya/domain/chat/controller/ChatController.java
@@ -5,9 +5,15 @@ import com.backend.simya.domain.chat.repository.ChatRoomRepository;
 import com.backend.simya.domain.chat.service.ChatService;
 import com.backend.simya.domain.jwt.service.AuthService;
 import com.backend.simya.domain.jwt.service.TokenProvider;
+import com.backend.simya.domain.profile.entity.Profile;
+import com.backend.simya.domain.user.entity.User;
+import com.backend.simya.domain.user.repository.UserRepository;
+import com.backend.simya.domain.user.service.UserService;
 import com.backend.simya.global.common.BaseException;
+import com.backend.simya.global.common.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.LazyInitializationException;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Controller;
@@ -25,6 +31,8 @@ public class ChatController {
     private final AuthService authService;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatService chatService;
+    private final TokenProvider tokenProvider;
+    private final UserRepository userRepository;
 
     /**
      * WebSocket "/pub/chat/message" 로 들어오는 메시징 처리
@@ -33,16 +41,25 @@ public class ChatController {
     public void message(ChatMessage message, @Header("token") String token) {
 
         try {
-            String nickname = authService.getUsername();
-            log.info("@MessageMapping - nickname: {}", nickname);
+            log.info("Web Socket Header 에서 읽어온 Access-Token: {}", token);
+            String authenticateUser = tokenProvider.getAuthentication(token).getName();
+            Profile profile = null;
 
-            message.setSender(nickname);         // 로그인 회원 정보로 대화명 설정
+            try {
+                log.info("ChatController - Authenticate User : {}", authenticateUser);
+                profile = chatService.getSessionToMainProfile(authenticateUser);
+            } catch (LazyInitializationException | BaseException e) {
+                log.error("유저와 대표 프로필 조회에 실패했습니다.");
+            }
+            log.info("@MessageMapping - authenticateUser: {} => nickname: {}", authenticateUser, profile);
+
+            message.setSender(profile.getNickname());         // 로그인 회원 정보로 대화명 설정
             message.setUserCount(chatRoomRepository.getUserCount(message.getRoomId()));  // 채팅방 인원 수 세팅
 
             // WebSocket 에 발행된 메시지를 Redis 로 발행(publish)s
             chatService.sendChatMessage(message);
-        } catch (BaseException e) {
-            log.error(e.getStatus().toString());
+        } catch (Exception e) {
+            log.error(e.getMessage());
         }
 
     }

--- a/src/main/java/com/backend/simya/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/simya/domain/chat/controller/ChatRoomController.java
@@ -2,6 +2,7 @@ package com.backend.simya.domain.chat.controller;
 
 import com.backend.simya.domain.chat.dto.ChatRoom;
 import com.backend.simya.domain.chat.repository.ChatRoomRepository;
+import com.backend.simya.domain.jwt.service.AuthService;
 import com.backend.simya.domain.jwt.service.TokenProvider;
 import com.backend.simya.domain.user.dto.response.ChatLoginInfo;
 import com.backend.simya.domain.user.entity.User;
@@ -26,6 +27,7 @@ public class ChatRoomController {
     private final ChatRoomRepository chatRoomRepository;
     private final TokenProvider tokenProvider;
     private final UserService userService;
+    private final AuthService authService;
 
     @GetMapping("/room")
     public String rooms(Model model) {
@@ -86,16 +88,18 @@ public class ChatRoomController {
     public ChatLoginInfo getUserInfo() {
         log.info("ChatLoginInfo 응답 객체 반환을 위한 준비");
         try {
-            User loginUser = userService.getMyUserWithAuthorities();
+//            User loginUser = userService.getMyUserWithAuthorities();
+            User loginUser = authService.authenticateUser();
 
             log.info("Authentication - {}", loginUser.getUsername());
 
-            String name = loginUser.getUsername();
+            int idx = loginUser.getMainProfile();
+            String name = loginUser.getProfileList().get(idx).getNickname();  // 대표 프로필의 닉네임으로 sender 명 지정
             String token = tokenProvider.getJwt().getAccessToken();
-            log.info("JWT Token - {}", token);
+            log.info("JWT nickname / Token - " + name + " " + token);
             return ChatLoginInfo.builder()
                     .name(name)
-                    .token(token)
+                    .token(token)  // TODO 프론트에서 "token" 키 값을 받아올 때 ChatLoginDto 의 값에서 가져오는 것
                     .build();
         } catch (BaseException e) {
             log.error("ChatLoginInfo 객체 생성 실패");

--- a/src/main/java/com/backend/simya/domain/chat/service/ChatService.java
+++ b/src/main/java/com/backend/simya/domain/chat/service/ChatService.java
@@ -78,19 +78,5 @@ public class ChatService {
         redisTemplate.convertAndSend(channelTopic.getTopic(), message);
     }
 
-    /**
-     * 채팅 메시지 발송자 - 세션 유저에서 대표 프로필 닉네임으로 설정
-     */
-    public Profile getSessionToMainProfile(String sessionUserName) throws BaseException{
-        User user = userRepository.findByEmail(sessionUserName).orElseThrow(
-                () -> new BaseException(BaseResponseStatus.FAILED_TO_FIND_USER)
-        );
-        Profile profile = user.getProfileList().get(user.getMainProfile());
-
-        log.info("[Header] simpUser: {} => 심야식당 서비스에서 찾은 유저: {} / 대표 프로필: {}", sessionUserName, user, profile);
-
-        return profile;
-
-    }
 }
 

--- a/src/main/java/com/backend/simya/domain/jwt/service/TokenProvider.java
+++ b/src/main/java/com/backend/simya/domain/jwt/service/TokenProvider.java
@@ -157,12 +157,13 @@ public class TokenProvider {
             HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
             log.info("AuthService -> TokenProvider - getJwt() : header에 저장된 Access Token {}", request.getHeader("Access-Token"));
-            log.info("AuthService -> TokenProvider - getJwt() : header에 저장된 Access Token {}", request.getHeader("Refresh-Token"));
+            log.info("AuthService -> TokenProvider - getJwt() : header에 저장된 Refresh Token {}", request.getHeader("Refresh-Token"));
             String accessToken = request.getHeader("Access-Token").substring(7);
             String refreshToken = request.getHeader("Refresh-Token").substring(8);
 
             return new TokenRequestDto(accessToken, refreshToken);
         } catch (Exception exception) {
+            log.error("TokenProvider - Header에서 JWT 가져오기 실패");
             throw new BaseException(INVALID_JWT);
         }
     }

--- a/src/main/java/com/backend/simya/domain/user/service/UserService.java
+++ b/src/main/java/com/backend/simya/domain/user/service/UserService.java
@@ -9,8 +9,10 @@ import com.backend.simya.domain.user.entity.Role;
 import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.domain.user.repository.UserRepository;
 import com.backend.simya.global.common.BaseException;
+import com.backend.simya.global.common.BaseResponseStatus;
 import com.backend.simya.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ import static com.backend.simya.global.common.BaseResponseStatus.*;
 /**
  * 회원가입, 유저정보조회 등의 API를 구현하기 위한 Service 클래스
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -95,6 +98,22 @@ public class UserService {
         } catch (Exception exception) {
             throw new BaseException(DELETE_FAIL_USER);
         }
+    }
+
+    /**
+     * 채팅 메시지 발송자 - 세션 유저에서 대표 프로필 닉네임으로 설정 시 사용
+     */
+    @Transactional
+    public Profile getSessionToMainProfile(String sessionUserName) throws BaseException{
+        User user = userRepository.findByEmail(sessionUserName).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.FAILED_TO_FIND_USER)
+        );
+        Profile profile = user.getProfileList().get(user.getMainProfile());
+
+        log.info("[Header] simpUser: {} => 심야식당 서비스에서 찾은 유저: {} / 대표 프로필: {}", sessionUserName, user, profile);
+
+        return profile;
+
     }
 
 }

--- a/src/main/java/com/backend/simya/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/simya/global/config/SecurityConfig.java
@@ -5,9 +5,11 @@ import com.backend.simya.global.config.jwt.JwtAccessDeniedHandler;
 import com.backend.simya.global.config.jwt.JwtAuthenticationEntryPoint;
 import com.backend.simya.global.config.jwt.JwtSecurityConfig;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -95,8 +97,6 @@ public class SecurityConfig {
         return (web) -> web.ignoring()
                 .antMatchers("/h2-console/**", "/favicon.ico", "/error");
     }
-
-
 
 }
 

--- a/src/main/java/com/backend/simya/global/config/jwt/JwtFilter.java
+++ b/src/main/java/com/backend/simya/global/config/jwt/JwtFilter.java
@@ -64,13 +64,12 @@ public class JwtFilter extends GenericFilterBean {
 
     // 필터링을 하려면 토큰 정보 필요 -> Request Header에서 토큰 정보를 꺼내오는 메소드
     private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        log.info("request = {}", request.getHeader("Access-Token"));
-        log.info("request = {}", request.getHeader("Authorization"));
-        log.info("BearerToken - {}", bearerToken);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            log.info("StringUtils.hasText 실행 - {}", bearerToken.substring(7));
-            return bearerToken.substring(7);
+        String accessToken = request.getHeader(AUTHORIZATION_HEADER);
+        log.info("request(Access-Token) = {}", request.getHeader("Access-Token"));
+        log.info("request(Authorization) = {}", request.getHeader("Authorization"));
+        if (StringUtils.hasText(accessToken) && accessToken.startsWith(BEARER_PREFIX)) {
+            log.info("StringUtils.hasText 실행 - {}", accessToken.substring(7));
+            return accessToken.substring(7);
         }
         return null;
     }

--- a/src/main/resources/templates/chat/roomdetail.ftl
+++ b/src/main/resources/templates/chat/roomdetail.ftl
@@ -64,6 +64,7 @@
             this.roomId = localStorage.getItem('wschat.roomId');
             this.roomName = localStorage.getItem('wschat.roomName');
             var _this = this;
+            console.log(this);
             axios.get('/chat/user').then(response => {
                 _this.token = response.data.token;
                 ws.connect({"token":_this.token}, function(frame) {
@@ -81,6 +82,7 @@
             sendMessage: function(type) {
                 ws.send("/pub/chat/message", {"token":this.token}, JSON.stringify({type:type, roomId:this.roomId, message:this.message}));
                 this.message = '';
+                console.log("Front token: " + this.token);
             },
             recvMessage: function(recv) {
                 this.userCount = recv.userCount;


### PR DESCRIPTION
### 변경 사항
1. 대표 프로필의 닉네임으로 발신자를 지정하도록 UserService에 유저에서 대표 프로필 찾는 로직 추가
2. WebSocket의 흐름 및 헤더 값 분석  **특히 JWT Token을 받아오기 위한 부분 & 클라이언트와 주고받는 요청&응답 헤더 값

### 학습 내용 정리
<ul>
<li>
<p>js에서 웹 소켓(/ws-stomp) 모듈을 import하고, 웹 소켓을 열면 StompHandler 에서 <code>StompHeaderAccessor</code>가StompCommand.CONNECT로 인식</p>
<p>→ 여기서 프론트가 아래 값으로 넘겨주므로 토큰 유효성 검사 진행 가능</p>
<pre><code class="language-jsx">// vue.js
var vm = new Vue({
    el: '#app',
    data: {
        roomId: '',
        roomName: '',
        message: '',
        messages: [],
        <b>token: '',</b>
        userCount: 0
    },
});
</code></pre>
</li>
<li>
<p>UserService에 채팅방에 접속한 클라이언트 세션 정보(simpSessionId, simpUser)를 바탕으로 당시의 대표 프로필 닉네임으로 DTO의 sender set 후에 넘겨줌</p>
<ul>
<li>DTO 값
<ul>
<li>ChatMessage
<ol>
<li>type (ENTER, TALK, QUIT)</li>
<li>roomId</li>
<li>sender</li>
<li>message</li>
<li>userCount</li>
</ol>
</li>
<li>ChatRoom
<ol>
<li>roomId</li>
<li>name</li>
<li>userCount</li>
</ol>
</li>
</ul>
</li>
</ul>
</li>
<li>
<p>명세서 preview</p>


URI | Method | Description
-- | -- | --
/ws-stomp | GET | WebSocket 연결
/chat/room | GET | View(room.ftl)로 연결
/chat/rooms | GET | 전체 채팅방 리스트 조회
/chat/room | POST | 채팅방 개설
/chat/room/enter/:roomId | GET | 채팅방 입장 처리[/sub/chat/room/:roomId] 후 View(roomdetail.ftl)로 연결 
/chat/room/:roomId | GET | 채팅방 ID(UUID)로 특정 채팅방 조회
/chat/user | GET | 클라이언트 정보를 가져와 발신자에 대한 정보(ChatLoginInfo) DTO 객체로 반환 → localStorage에 저장 |   |  
<b>/pub</b>/chat/message | Message | token, ChatMessage DTO로 넘겨준 정보로 메시지 전송
<b>/sub</b>/chat/room/:roomId | Message | 웹 소켓의 simpDestination 헤더 값으로  roomId가 들어가 채팅방에서 실시간 통신이 가능하게 됨




</li>
</ul>

### 참고사항
- [ ] 테스트 시, Header에 Access-Token , Refresh-Token 꼭 둘 다 넣어주기 (아니면 TokenProvider의 getJwt()에서 걸려서 오류 남)

close #38 
