### PR TITLE
[ Feat ] #50 androidconnect

### DIFF
--- a/src/main/java/com/backend/simya/domain/chat/dto/ChatMessageCustom.java
+++ b/src/main/java/com/backend/simya/domain/chat/dto/ChatMessageCustom.java
@@ -1,0 +1,32 @@
+package com.backend.simya.domain.chat.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class ChatMessageCustom {
+    public ChatMessageCustom() {
+
+    }
+
+    @Builder
+    public ChatMessageCustom(ChatMessage.MessageType type, String roomId, String sender, String token, String message, long userCount) {
+        this.type = type;
+        this.roomId = roomId;
+        this.sender = sender;
+        this.token = token;
+        this.message = message;
+        this.userCount = userCount;
+    }
+
+    public enum MessageType {
+        ENTER, TALK, QUIT
+    }
+
+    private ChatMessage.MessageType type;   // 메시지 유형
+    private String roomId;   // 방 번호
+    private String sender;
+    private String token;// 발신자
+    private String message;  // 메시지 데이터
+    private long userCount;  // 채팅방 인원 수: 채팅방 내에서 메시지가 전달될 때 인원 수 갱신
+}

--- a/src/main/java/com/backend/simya/domain/chat/dto/ChatMessageCustom.java
+++ b/src/main/java/com/backend/simya/domain/chat/dto/ChatMessageCustom.java
@@ -10,10 +10,11 @@ public class ChatMessageCustom {
     }
 
     @Builder
-    public ChatMessageCustom(ChatMessage.MessageType type, String roomId, String sender, String token, String message, long userCount) {
+    public ChatMessageCustom(ChatMessage.MessageType type, String roomId, String sender, String picture, String token, String message, long userCount) {
         this.type = type;
         this.roomId = roomId;
         this.sender = sender;
+        this.picture = picture;
         this.token = token;
         this.message = message;
         this.userCount = userCount;
@@ -26,6 +27,7 @@ public class ChatMessageCustom {
     private ChatMessage.MessageType type;   // 메시지 유형
     private String roomId;   // 방 번호
     private String sender;
+    private String picture;
     private String token;// 발신자
     private String message;  // 메시지 데이터
     private long userCount;  // 채팅방 인원 수: 채팅방 내에서 메시지가 전달될 때 인원 수 갱신

--- a/src/main/java/com/backend/simya/domain/chat/dto/ChatRoom.java
+++ b/src/main/java/com/backend/simya/domain/chat/dto/ChatRoom.java
@@ -34,6 +34,15 @@ public class ChatRoom implements Serializable {
         return chatRoom;
     }
 
+    public static ChatRoom createForAndroid(String roomId) {
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.roomId = roomId;
+        chatRoom.name = "새로움";
+        chatRoom.profileList = new ArrayList<>();
+        return chatRoom;
+    }
+
+
     public void addProfile(Profile profile) {
         this.profileList.add(ProfileResponseDto.from(profile));
     }

--- a/src/main/java/com/backend/simya/domain/chat/dto/ChatRoomForAndroid.java
+++ b/src/main/java/com/backend/simya/domain/chat/dto/ChatRoomForAndroid.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ChatRoomForAndroid implements ChatRoomInterface {
 
-    private static final long serialVersionUID = 6494678977089006639L;
+    //private static final long serialVersionUID = 6494678977089006639L;
 
     private Long roomId;
     private Long userCount;

--- a/src/main/java/com/backend/simya/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/backend/simya/domain/chat/repository/ChatRoomRepository.java
@@ -70,6 +70,10 @@ public class ChatRoomRepository {
         return chatRoom;
     }
 
+    public void saveChatRoom(ChatRoom chatRoom) {
+        hashOpsChatRoom.put(CHAT_ROOMS, chatRoom.getRoomId(), chatRoom);
+    }
+
     /**
      * 유저가 입장한 채팅방 정보(roomId)와 유저 세션 정보(sessionId) 매핑하여 저장
      */
@@ -97,6 +101,11 @@ public class ChatRoomRepository {
     public long getUserCount(String roomId) {
         return Long.parseLong(Optional.ofNullable(valueOps.get(USER_COUNT + "_" + roomId)).orElse("0"));
     }
+
+    public void removeChatRoom(String roomId) {
+        hashOpsChatRoom.delete(CHAT_ROOMS, roomId);
+    }
+
 
     /**
      * 채팅방에 새로운 유저가 입장한 경우 => 인원 수 +1

--- a/src/main/java/com/backend/simya/domain/chat/service/ChatService.java
+++ b/src/main/java/com/backend/simya/domain/chat/service/ChatService.java
@@ -3,7 +3,10 @@ package com.backend.simya.domain.chat.service;
 
 import com.backend.simya.domain.chat.dto.ChatMessage;
 import com.backend.simya.domain.chat.dto.ChatMessageCustom;
+import com.backend.simya.domain.chat.dto.ChatRoom;
+import com.backend.simya.domain.chat.dto.ChatRoomForAndroid;
 import com.backend.simya.domain.chat.repository.ChatRoomRepository;
+import com.backend.simya.domain.house.dto.request.HouseOpenRequestDto;
 import com.backend.simya.domain.profile.entity.Profile;
 import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.domain.user.repository.UserRepository;
@@ -44,20 +47,24 @@ public class ChatService {
         }
     }
 
-    /*
-     * 채팅방 생성 - Random UUID 를 ID 로 가지는 채팅방 객체 생성 -> chatRooms 에 추가
-     * **ID는 식별자로, 조회 시 사용
-     */
+    public void openChatRoom(HouseOpenRequestDto houseOpenRequestDto) {
+        chatRoomRepository.saveChatRoom(ChatRoom.createForAndroid(String.valueOf(houseOpenRequestDto.getHouseId())));
+    }
 
-    /*public ChatRoom createRoom(String name) {
-        String randomId = UUID.randomUUID().toString();
-        ChatRoom chatRoom = ChatRoom.builder()
-                .roomId(randomId)
-                .name(name)
-                .build();
-        chatRooms.put(randomId, chatRoom);   // 채팅방 리스트에 새로 개설한 채팅방 추가
-        return chatRoom;
-    }*/
+    public void enterChatRoom(String sessionId, String roomId) {
+        chatRoomRepository.setUserEnterInfo(sessionId, roomId);
+        chatRoomRepository.plusUserCount(roomId);  // 인원 수 +1
+    }
+
+    public void exitChatRoom(String sessionId, String roomId) {
+        chatRoomRepository.removeUserEnterInfo(sessionId);
+        chatRoomRepository.minusUserCount(roomId);  // 인원 수 +1
+    }
+
+    public void closeChatRoom(Long roomId) {
+        chatRoomRepository.removeChatRoom(String.valueOf(roomId));
+    }
+
 
     /*
      * 메시지 발송 - 지정한 웹 소켓 세션으로 메시지 발송

--- a/src/main/java/com/backend/simya/domain/chat/service/ChatService.java
+++ b/src/main/java/com/backend/simya/domain/chat/service/ChatService.java
@@ -2,6 +2,7 @@ package com.backend.simya.domain.chat.service;
 
 
 import com.backend.simya.domain.chat.dto.ChatMessage;
+import com.backend.simya.domain.chat.dto.ChatMessageCustom;
 import com.backend.simya.domain.chat.repository.ChatRoomRepository;
 import com.backend.simya.domain.profile.entity.Profile;
 import com.backend.simya.domain.user.entity.User;
@@ -77,6 +78,22 @@ public class ChatService {
         }
         redisTemplate.convertAndSend(channelTopic.getTopic(), message);
     }
+
+    public void sendChatMessage(ChatMessageCustom message) {
+        message.setUserCount(chatRoomRepository.getUserCount(message.getRoomId()));
+
+        if (ChatMessage.MessageType.ENTER.equals(message.getType())) {
+            log.info(message.getSender() + "님이 방에 입장했습니다");
+            message.setMessage(message.getSender() + "님이 방에 입장했습니다");
+            message.setSender("[알림]");
+        } else if (ChatMessage.MessageType.QUIT.equals(message.getType())) {
+            log.info(message.getSender() + "님이 방에서 나갔습니다.");
+            message.setMessage(message.getSender() + "님이 방에서 나갔습니다.");
+            message.setSender("[알림]");
+        }
+        redisTemplate.convertAndSend(channelTopic.getTopic(), message);
+    }
+
 
 }
 

--- a/src/main/java/com/backend/simya/domain/chat/service/RedisPublisher.java
+++ b/src/main/java/com/backend/simya/domain/chat/service/RedisPublisher.java
@@ -1,6 +1,7 @@
 package com.backend.simya.domain.chat.service;
 
 import com.backend.simya.domain.chat.dto.ChatMessage;
+import com.backend.simya.domain.chat.dto.ChatMessageCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
@@ -18,7 +19,7 @@ public class RedisPublisher {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    public void publish(ChannelTopic topic, ChatMessage message) {
+    public void publish(ChannelTopic topic, ChatMessageCustom message) {
         redisTemplate.convertAndSend(topic.getTopic(), message);
     }
 }

--- a/src/main/java/com/backend/simya/domain/chat/service/RedisSubscriber.java
+++ b/src/main/java/com/backend/simya/domain/chat/service/RedisSubscriber.java
@@ -1,6 +1,7 @@
 package com.backend.simya.domain.chat.service;
 
 import com.backend.simya.domain.chat.dto.ChatMessage;
+import com.backend.simya.domain.chat.dto.ChatMessageCustom;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,7 @@ public class RedisSubscriber {
         try {
             log.info("objectMapper.readValue() 전");
             // ChatMessage 객체로 매핑
-            ChatMessage chatMessage = objectMapper.readValue(publishMessage, ChatMessage.class);
+            ChatMessageCustom chatMessage = objectMapper.readValue(publishMessage, ChatMessageCustom.class);
             log.info("objectMapper.readValue() 후");
 
             // WebSocket 구독자에게 채팅 메시지 Send

--- a/src/main/java/com/backend/simya/domain/house/controller/HouseController.java
+++ b/src/main/java/com/backend/simya/domain/house/controller/HouseController.java
@@ -1,5 +1,6 @@
 package com.backend.simya.domain.house.controller;
 
+import com.backend.simya.domain.chat.service.ChatService;
 import com.backend.simya.domain.chat.service.ChatServiceForAndroid;
 import com.backend.simya.domain.house.dto.request.HouseOpenRequestDto;
 import com.backend.simya.domain.house.dto.request.HouseUpdateRequestDto;
@@ -38,7 +39,7 @@ public class HouseController {
     private final UserService userService;
     private final TopicService topicService;
     private final ProfileService profileService;
-    private final ChatServiceForAndroid chatService;
+    private final ChatService chatService;
 
 
     @GetMapping("")

--- a/src/main/java/com/backend/simya/domain/house/controller/HouseController.java
+++ b/src/main/java/com/backend/simya/domain/house/controller/HouseController.java
@@ -1,5 +1,7 @@
 package com.backend.simya.domain.house.controller;
 
+import com.backend.simya.domain.chat.dto.ChatRoomProfile;
+import com.backend.simya.domain.chat.repository.ChatRoomRepository;
 import com.backend.simya.domain.chat.service.ChatService;
 import com.backend.simya.domain.chat.service.ChatServiceForAndroid;
 import com.backend.simya.domain.house.dto.request.HouseOpenRequestDto;
@@ -40,6 +42,7 @@ public class HouseController {
     private final TopicService topicService;
     private final ProfileService profileService;
     private final ChatService chatService;
+    private final ChatRoomRepository chatRoomRepository;
 
 
     @GetMapping("")
@@ -153,6 +156,12 @@ public class HouseController {
             return new BaseResponse<>(DATABASE_ERROR);
         }
     }
+
+    @GetMapping("/{houseId}/guest")
+    public BaseResponse<List<ChatRoomProfile>> getCurrentGuestsProfile(@PathVariable("houseId") Long houseId) {
+        return new BaseResponse<>(chatRoomRepository.getRoomProfileList(String.valueOf(houseId)));
+    }
+
 
     @PostMapping("/{houseId}/topic")
     public BaseResponse<TopicResponseDto> registerNewTopic(@PathVariable("houseId") Long houseId,

--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.backend.simya.domain.profile.entity.Profile;
 import com.backend.simya.domain.profile.service.ProfileService;
 import com.backend.simya.domain.user.dto.request.LoginDto;
 import com.backend.simya.domain.user.dto.request.UserDto;
+import com.backend.simya.domain.user.dto.response.FormLoginResponseDto;
 import com.backend.simya.domain.user.entity.User;
 import com.backend.simya.domain.user.service.UserService;
 import com.backend.simya.global.common.BaseException;
@@ -75,7 +76,7 @@ public class UserController {
             User currentUser = userService.getMyUserWithAuthorities();
             Profile mainProfile = currentUser.getProfileList().get(currentUser.getMainProfile());
 
-            return new BaseResponse<>(ProfileResponseDto.from(mainProfile));
+            return new BaseResponse<>(FormLoginResponseDto.from(mainProfile, accessToken, refreshToken));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/com/backend/simya/domain/user/controller/UserController.java
+++ b/src/main/java/com/backend/simya/domain/user/controller/UserController.java
@@ -2,6 +2,9 @@ package com.backend.simya.domain.user.controller;
 
 import com.backend.simya.domain.jwt.dto.response.TokenDto;
 import com.backend.simya.domain.jwt.service.AuthService;
+import com.backend.simya.domain.profile.dto.response.ProfileResponseDto;
+import com.backend.simya.domain.profile.entity.Profile;
+import com.backend.simya.domain.profile.service.ProfileService;
 import com.backend.simya.domain.user.dto.request.LoginDto;
 import com.backend.simya.domain.user.dto.request.UserDto;
 import com.backend.simya.domain.user.entity.User;
@@ -69,7 +72,10 @@ public class UserController {
             response.addHeader(JwtFilter.AUTHORIZATION_HEADER, "Access " + accessToken);
             response.addHeader(JwtFilter.REFRESH_HEADER, "Refresh " + refreshToken);
 
-            return new BaseResponse<>(tokenDto);
+            User currentUser = userService.getMyUserWithAuthorities();
+            Profile mainProfile = currentUser.getProfileList().get(currentUser.getMainProfile());
+
+            return new BaseResponse<>(ProfileResponseDto.from(mainProfile));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/com/backend/simya/domain/user/dto/response/FormLoginResponseDto.java
+++ b/src/main/java/com/backend/simya/domain/user/dto/response/FormLoginResponseDto.java
@@ -1,0 +1,35 @@
+package com.backend.simya.domain.user.dto.response;
+
+import com.backend.simya.domain.house.entity.Topic;
+import com.backend.simya.domain.profile.entity.Profile;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FormLoginResponseDto {
+
+    private Long profileId;
+    private String nickname;
+    private String picture;
+    private String comment;
+    private String accessToken;
+    private String refreshToken;
+
+    public static FormLoginResponseDto from(Profile profile, String accessToken, String refreshToken) {
+        return FormLoginResponseDto.builder()
+                .profileId(profile.getProfileId())
+                .nickname(profile.getNickname())
+                .comment(profile.getComment())
+                .comment(profile.getComment())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/simya/global/config/websocket/handler/StompHandler.java
+++ b/src/main/java/com/backend/simya/global/config/websocket/handler/StompHandler.java
@@ -80,6 +80,7 @@ public class StompHandler implements ChannelInterceptor {
                         .type(ChatMessage.MessageType.ENTER)
                         .roomId(roomId)
                         .sender(profile.getNickname())
+                        .token(tokenProvider.getJwt().getAccessToken())
                         .picture(profile.getPicture())
                         .build());
                 log.info("SUBSCRIBED {}, {}", name, roomId);
@@ -108,6 +109,7 @@ public class StompHandler implements ChannelInterceptor {
                         .type(ChatMessage.MessageType.QUIT)
                         .roomId(roomId)
                         .sender(profile.getNickname())
+                        .token(tokenProvider.getJwt().getAccessToken())
                         .picture(profile.getPicture())
                         .build());
             } catch (LazyInitializationException | BaseException e) {


### PR DESCRIPTION
기존의 웹sock 환경은 건드리지 않고 개발했습니다

안드로이드 stomp 라이브러리의 기능이 많지 않아 message header를 추가하는 방법을 찾지못했고
body에 token을 넣는 방법으로 해결했습니다

houseController -> openHouse API에 openChatRoom 로직을 추가했고
그렇게 열린 chatRoom의 chatRoomId는 houseId와 같은 값으로 저장됩니다

이제 publish되는 메시지에 해당 프로필의 picture가 들어가게 됩니다

추가적으로 프론트 측에서 토큰과 대표 프로필 정보를 담은 로그인 응답 데이터를 요청해 요청대로 적용했습니다
현재 이야기 집에 입장해있는 프로필 리스트 조회 API 구현했습니다